### PR TITLE
Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ build/
 dist/
 python/_version.py
 benchmarks/files/ldbc/*/
+# local benchmark harness outputs
+benchmarks/files/sql/_local/

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ test.1
 benchmarks/files/asp/actual/
 benchmarks/files/asp/expected/
 benchmarks/downloads/
+benchmarks/files/sql/input/downloads/
 test/e2e/files/asp/actual/
 test/unit/bumblebee/function/data/output
 test/e2e/files/csv/mini_hits.csv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,14 @@ project(BumbleBee)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 
+# Force-include a small prelude of standard headers into every translation
+# unit. libstdc++ (GCC) does not transitively expose as many standard headers
+# as libc++, so sources that relied on those transitive includes fail to build.
+# See src/include/std_prelude.hpp. (GCC/Clang flag; skip on MSVC.)
+if(NOT MSVC)
+    add_compile_options(-include ${CMAKE_SOURCE_DIR}/src/include/std_prelude.hpp)
+endif()
+
 # Enable AddressSanitizer only for Debug builds
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(STATUS "Building with AddressSanitizer in Debug mode")

--- a/benchmarks/bench_local.py
+++ b/benchmarks/bench_local.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Local head-to-head benchmark: BumbleBee vs DuckDB on identical synthetic data.
+
+Runs each query file with both engines on this machine (default 4 threads),
+reports per-query timings, the gap vs DuckDB, and whether outputs match.
+This is the apples-to-apples measurement used to drive optimization, since the
+recorded 50-core/real-data CSVs cannot be reproduced here.
+
+Usage:
+  bench_local.py [--bb ../cmake-build-release/BumbleBee] [--threads 4]
+                 [--tries 2] [--queries q33,q32,...] [--csv]
+                 [--baseline file.json] [--out file.json]
+"""
+import argparse, json, os, re, subprocess, time, sys
+from pathlib import Path
+from statistics import median
+
+import duckdb
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from test.e2e.utils import compare_csv
+
+HERE = Path(__file__).resolve().parent
+INPUT = HERE / "files" / "sql" / "input"
+DUCK_INPUT = HERE / "files" / "sql" / "duckdb_input"
+
+# Parquet ClickBench queries (the q* set the task targets) + a couple CSV ones.
+PARQUET_Q = ["q00","q01","q02","q03","q06","q07","q12","q14","q19","q20","q21",
+             "q25","q26","q30","q32","q33","q36"]
+CSV_Q = ["q00","q01","q02","q03","q06","q14","q19","q30"]
+
+def read_sql(path):
+    lines = path.read_text().splitlines()
+    if lines and lines[0].strip().startswith("%@sql"):
+        lines = lines[1:]
+    return "\n".join(lines).strip()
+
+def run_bb(bb, infile, threads, out_path):
+    # Export query result to CSV so we can compare; mirror benchmark_runner.
+    sql = infile.read_text()
+    export = f'COPY (\n{read_sql(infile)}\n) TO "{out_path}" (single_file=1)'
+    tmp = out_path.with_suffix(".bbinput.sql")
+    if sql.splitlines()[0].strip().startswith("%@sql"):
+        tmp.write_text("%@sql\n" + export)
+    else:
+        tmp.write_text(export)
+    t0 = time.perf_counter()
+    r = subprocess.run(f'{bb} -t {threads} -i {tmp}', shell=True,
+                       capture_output=True, text=True, timeout=600)
+    dt = time.perf_counter() - t0
+    tmp.unlink(missing_ok=True)
+    if r.returncode != 0:
+        return dt, None, (r.stderr or r.stdout)[-500:]
+    return dt, out_path, None
+
+def run_duck(con, infile, threads, out_path):
+    con.execute(f"PRAGMA threads={threads}")
+    q = read_sql(infile)
+    t0 = time.perf_counter()
+    con.execute(f'COPY ({q}) TO \'{out_path}\' (HEADER, DELIMITER \',\')')
+    dt = time.perf_counter() - t0
+    return dt, out_path
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bb", default=str(HERE.parent / "cmake-build-release" / "BumbleBee"))
+    ap.add_argument("--threads", type=int, default=4)
+    ap.add_argument("--tries", type=int, default=2)
+    ap.add_argument("--queries", default="")
+    ap.add_argument("--csv", action="store_true", help="run CSV variants instead of parquet")
+    ap.add_argument("--baseline", default="")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    suffix = ".sql" if args.csv else ".parquet.sql"
+    qlist = (args.queries.split(",") if args.queries
+             else (CSV_Q if args.csv else PARQUET_Q))
+
+    outdir = HERE / "files" / "sql" / "_local"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    baseline = {}
+    if args.baseline and Path(args.baseline).exists():
+        baseline = json.load(open(args.baseline))
+
+    con = duckdb.connect()
+    results = {}
+    print(f"{'query':<14}{'BB(s)':>9}{'Duck(s)':>9}{'gap%':>8}{'vsBase':>9}  match")
+    print("-"*64)
+    for q in qlist:
+        infile = INPUT / f"{q}{suffix}"
+        duckfile = DUCK_INPUT / f"{q}{suffix}"
+        if not infile.exists() or not duckfile.exists():
+            continue
+        # DuckDB (uses the duckdb_input variant: '' literals, real column case)
+        dts_d = []
+        dpath = outdir / f"{q}.duck.csv"
+        for _ in range(args.tries):
+            dt, _ = run_duck(con, duckfile, args.threads, dpath)
+            dts_d.append(dt)
+        # BumbleBee
+        dts_b = []
+        bpath = outdir / f"{q}.bb.csv"
+        err = None
+        for _ in range(args.tries):
+            dt, op, err = run_bb(args.bb, infile, args.threads, bpath)
+            dts_b.append(dt)
+            if err: break
+        bb = median(dts_b)
+        dk = median(dts_d)
+        try:
+            match = "ERR" if err else ("match" if compare_csv(str(bpath), str(dpath)) else "MISMATCH")
+        except Exception as e:
+            match = f"CMP?({e})"[:20]
+        gap = (bb - dk) / dk * 100 if dk > 0 else 0
+        base = baseline.get(q)
+        vsbase = f"{(bb-base)/base*100:+.0f}%" if base else "-"
+        results[q] = bb
+        flag = "" if err is None else "  <<<"+ (err.replace(chr(10)," ")[:120])
+        print(f"{q:<14}{bb:>9.3f}{dk:>9.3f}{gap:>7.0f}%{vsbase:>9}  {match}{flag}")
+    print("-"*64)
+    tot_bb = sum(results.values())
+    print(f"{'TOTAL BB':<14}{tot_bb:>9.3f}")
+    if args.out:
+        json.dump(results, open(args.out, "w"), indent=2)
+        print(f"saved -> {args.out}")
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/gen_synthetic_hits.py
+++ b/benchmarks/gen_synthetic_hits.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Generate a synthetic ClickBench-"hits" dataset.
+
+The real ClickBench dataset (datasets.clickhouse.com / huggingface) is not
+reachable from this environment, so we synthesize a dataset with the SAME
+105-column schema and column NAMES, giving the ~15 query-relevant columns
+realistic cardinalities / skew and the other ~90 columns cheap values. This
+reproduces ClickBench's defining shape (very wide table, queries touch a few
+columns) so projection-pushdown, parallel scan, high-cardinality GROUP BY and
+string filtering are all exercised the same way the real benchmark exercises
+them. Both DuckDB and BumbleBee read the identical file, so the engine-vs-engine
+gap is measured apples-to-apples.
+
+Usage: gen_synthetic_hits.py <rows> <out.parquet> [threads] [row_group_size]
+"""
+import sys, duckdb
+
+rows = int(sys.argv[1])
+out = sys.argv[2]
+threads = int(sys.argv[3]) if len(sys.argv) > 3 else 4
+rgs = int(sys.argv[4]) if len(sys.argv) > 4 else 122880
+
+# Query-relevant columns get realistic generators; everything else is cheap.
+# URL: 30% drawn from a small "popular" head (so top-N GROUP BY is meaningful),
+# 70% a high-cardinality long tail. ~20% of tail domains contain 'google'
+# (Q20/Q21 filter URL LIKE '%google%').
+expr = {
+    # near-unique hit id -> Q32 GROUP BY WatchID,ClientIP makes ~N groups
+    '"WatchID"': "(random()*9e18)::BIGINT",
+    '"ClientIP"': "(random()*2000000)::INTEGER",          # ~2M distinct
+    '"RegionID"': "(random()*9000)::INTEGER",
+    # UserID: mostly random (Q03 AVG), with the Q19 probe value injected sparsely
+    '"UserID"': "CASE WHEN random() < 0.00001 THEN 435090932899640449 ELSE (random()*9e18)::BIGINT END",
+    '"CounterID"': "(random()*5000)::INTEGER",            # Q36 CounterID=62 exists
+    '"EventDate"': "DATE '2013-07-01' + (random()*30)::INTEGER",
+    '"EventTime"': "TIMESTAMP '2013-07-01' + ((random()*2592000)::INTEGER * INTERVAL 1 SECOND)",
+    '"ResolutionWidth"': "(random()*2500)::SMALLINT",     # Q02/Q30/Q32 AVG
+    '"SearchEngineID"': "(random()*30)::SMALLINT",        # low card
+    '"AdvEngineID"': "CASE WHEN random() < 0.02 THEN (random()*40)::SMALLINT ELSE 0 END",  # ~98% zero
+    '"IsRefresh"': "CASE WHEN random() < 0.15 THEN 1 ELSE 0 END",
+    '"DontCountHits"': "CASE WHEN random() < 0.05 THEN 1 ELSE 0 END",
+    # SearchPhrase: ~85% empty; non-empty drawn with skew from a phrase pool
+    '"SearchPhrase"': (
+        "CASE WHEN random() < 0.85 THEN '' "
+        "ELSE 'phrase ' || (pow(random(),2)*20000)::INTEGER::VARCHAR END"
+    ),
+    # URL with realistic head/tail + google matches
+    '"URL"': (
+        "CASE WHEN random() < 0.3 "
+        "THEN (['http://google.com/', 'http://mail.google.com/inbox', "
+        "'http://example.com/', 'http://yandex.ru/news', 'http://shop.site/cart', "
+        "'http://news.site/top', 'http://video.site/watch', 'http://maps.google.com/', "
+        "'http://forum.site/thread', 'http://blog.site/post'])[(random()*9)::INTEGER + 1] "
+        "ELSE 'http://' || "
+        "(['google.com','mail.google.com','maps.google.com','example.com','yandex.ru',"
+        "'news.site','shop.site','video.site','forum.site','blog.site'])[(random()*9)::INTEGER + 1] "
+        "|| '/p' || (random()*1000000)::INTEGER::VARCHAR END"
+    ),
+}
+
+# Build column list from the canonical schema (name, type) in declaration order.
+schema = [
+ ('WatchID','BIGINT'),('JavaEnable','SMALLINT'),('Title','TEXT'),('GoodEvent','SMALLINT'),
+ ('EventTime','TIMESTAMP'),('EventDate','DATE'),('CounterID','INTEGER'),('ClientIP','INTEGER'),
+ ('RegionID','INTEGER'),('UserID','BIGINT'),('CounterClass','SMALLINT'),('OS','SMALLINT'),
+ ('UserAgent','SMALLINT'),('URL','TEXT'),('Referer','TEXT'),('IsRefresh','SMALLINT'),
+ ('RefererCategoryID','SMALLINT'),('RefererRegionID','INTEGER'),('URLCategoryID','SMALLINT'),
+ ('URLRegionID','INTEGER'),('ResolutionWidth','SMALLINT'),('ResolutionHeight','SMALLINT'),
+ ('ResolutionDepth','SMALLINT'),('FlashMajor','SMALLINT'),('FlashMinor','SMALLINT'),
+ ('FlashMinor2','TEXT'),('NetMajor','SMALLINT'),('NetMinor','SMALLINT'),('UserAgentMajor','SMALLINT'),
+ ('UserAgentMinor','VARCHAR'),('CookieEnable','SMALLINT'),('JavascriptEnable','SMALLINT'),
+ ('IsMobile','SMALLINT'),('MobilePhone','SMALLINT'),('MobilePhoneModel','TEXT'),('Params','TEXT'),
+ ('IPNetworkID','INTEGER'),('TraficSourceID','SMALLINT'),('SearchEngineID','SMALLINT'),
+ ('SearchPhrase','TEXT'),('AdvEngineID','SMALLINT'),('IsArtifical','SMALLINT'),
+ ('WindowClientWidth','SMALLINT'),('WindowClientHeight','SMALLINT'),('ClientTimeZone','SMALLINT'),
+ ('ClientEventTime','TIMESTAMP'),('SilverlightVersion1','SMALLINT'),('SilverlightVersion2','SMALLINT'),
+ ('SilverlightVersion3','INTEGER'),('SilverlightVersion4','SMALLINT'),('PageCharset','TEXT'),
+ ('CodeVersion','INTEGER'),('IsLink','SMALLINT'),('IsDownload','SMALLINT'),('IsNotBounce','SMALLINT'),
+ ('FUniqID','BIGINT'),('OriginalURL','TEXT'),('HID','INTEGER'),('IsOldCounter','SMALLINT'),
+ ('IsEvent','SMALLINT'),('IsParameter','SMALLINT'),('DontCountHits','SMALLINT'),('WithHash','SMALLINT'),
+ ('HitColor','VARCHAR'),('LocalEventTime','TIMESTAMP'),('Age','SMALLINT'),('Sex','SMALLINT'),
+ ('Income','SMALLINT'),('Interests','SMALLINT'),('Robotness','SMALLINT'),('RemoteIP','INTEGER'),
+ ('WindowName','INTEGER'),('OpenerName','INTEGER'),('HistoryLength','SMALLINT'),('BrowserLanguage','TEXT'),
+ ('BrowserCountry','TEXT'),('SocialNetwork','TEXT'),('SocialAction','TEXT'),('HTTPError','SMALLINT'),
+ ('SendTiming','INTEGER'),('DNSTiming','INTEGER'),('ConnectTiming','INTEGER'),
+ ('ResponseStartTiming','INTEGER'),('ResponseEndTiming','INTEGER'),('FetchTiming','INTEGER'),
+ ('SocialSourceNetworkID','SMALLINT'),('SocialSourcePage','TEXT'),('ParamPrice','BIGINT'),
+ ('ParamOrderID','TEXT'),('ParamCurrency','TEXT'),('ParamCurrencyID','SMALLINT'),
+ ('OpenstatServiceName','TEXT'),('OpenstatCampaignID','TEXT'),('OpenstatAdID','TEXT'),
+ ('OpenstatSourceID','TEXT'),('UTMSource','TEXT'),('UTMMedium','TEXT'),('UTMCampaign','TEXT'),
+ ('UTMContent','TEXT'),('UTMTerm','TEXT'),('FromTag','TEXT'),('HasGCLID','SMALLINT'),
+ ('RefererHash','BIGINT'),('URLHash','BIGINT'),('CLID','INTEGER'),
+]
+
+def default_expr(t):
+    if t in ('TEXT','VARCHAR'):
+        return "''"
+    if t == 'BIGINT':
+        return "(random()*1000000)::BIGINT"
+    if t == 'DATE':
+        return "DATE '2013-07-15'"
+    if t == 'TIMESTAMP':
+        return "TIMESTAMP '2013-07-15'"
+    if t == 'INTEGER':
+        return "(random()*1000)::INTEGER"
+    # SMALLINT
+    return "(random()*100)::SMALLINT"
+
+cols = []
+for name, t in schema:
+    key = f'"{name}"'
+    e = expr.get(key, default_expr(t))
+    cols.append(f'{e} AS "{name}"')
+
+sql = (
+    "COPY (SELECT\n  " + ",\n  ".join(cols) +
+    f"\nFROM range({rows})) TO '{out}' (FORMAT parquet, ROW_GROUP_SIZE {rgs}, COMPRESSION snappy)"
+)
+
+con = duckdb.connect()
+con.execute(f"PRAGMA threads={threads}")
+con.execute("PRAGMA enable_progress_bar")
+print(f"Generating {rows:,} rows -> {out} (threads={threads}, row_group_size={rgs})", flush=True)
+con.execute(sql)
+n = con.execute(f"SELECT count(*) FROM '{out}'").fetchone()[0]
+print(f"Done: {n:,} rows", flush=True)

--- a/src/BumbleBeeDB.cpp
+++ b/src/BumbleBeeDB.cpp
@@ -331,7 +331,10 @@ void BumbleBeeDB::print() {
         }
     }
     if (context_.printProfiling_) {
-        LOG_INFO("\n\n%s\n%s", profilingReport_.c_str(), FunctionProfiler::instance().toString().c_str());
+        // The -r flag is an explicit user request for the profiling report, so emit
+        // it to stderr directly (LOG_INFO is compiled out in Release at LOG_LEVEL=2).
+        fprintf(stderr, "\n\n%s\n%s\n", profilingReport_.c_str(),
+                FunctionProfiler::instance().toString().c_str());
     }
 }
 

--- a/src/BumbleBeeDB.cpp
+++ b/src/BumbleBeeDB.cpp
@@ -30,6 +30,7 @@
 #include "bumblebee/planner/Planner.hpp"
 #include "bumblebee/planner/StatementDependency.hpp"
 #include "bumblebee/planner/rewriter/AggregatesRewriter.hpp"
+#include "bumblebee/planner/rewriter/MetadataAggRewriter.hpp"
 
 namespace bumblebee {
 
@@ -146,6 +147,10 @@ void BumbleBeeDB::runFromInputString(const string &inputProgram) {
 }
 
 void BumbleBeeDB::processProgram(rules_vector_t& program, Scheduler& scheduler) {
+    // fold COUNT(*) over an unfiltered parquet scan into a constant from metadata
+    MetadataAggRewriter metadataRewriter(context_);
+    metadataRewriter.rewrite(program);
+
     // rewrite the aggregates
     AggregatesRewriter rewriter(context_);
     rewriter.rewrite(program);

--- a/src/catalog/PredicateTables.cpp
+++ b/src/catalog/PredicateTables.cpp
@@ -48,6 +48,13 @@ void PredicateTables::addFact(Atom &atom) {
         // inferred from the first non-NULL fact (or defaults to INTEGER if all
         // facts are NULL, see loadFacts).
         if (i < atomTerms.size() && atomTerms[i].isNull()) continue;
+        // A constant carrying an explicit logical type (e.g. a DATE folded from
+        // parquet statistics) sets the column's logical type directly, so output
+        // formatting and downstream typing match the un-folded query.
+        if (i < atomTerms.size() && atomTerms[i].hasExplicitLogicalType()) {
+            types_[i] = atomTerms[i].getLogicalType();
+            continue;
+        }
         if (types[i] == types_[i].getPhysicalType()) continue;
         types_[i] = {getCommonType(types_[i], types[i])};
     }

--- a/src/common/Allocator.cpp
+++ b/src/common/Allocator.cpp
@@ -26,6 +26,11 @@ AllocatedData::AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t all
 }
 
 AllocatedData::~AllocatedData() {
+    // Free the underlying allocation. Without this, every owner that relies on
+    // destruction (ResizeableBuffer on resize/destroy - i.e. every decompressed
+    // parquet page buffer) leaked its memory until process exit, so scan RSS grew
+    // with the number of row groups read instead of the working set.
+    reset();
 }
 
 void AllocatedData::reset() {

--- a/src/common/BufferedCSVReader.cpp
+++ b/src/common/BufferedCSVReader.cpp
@@ -611,7 +611,9 @@ void BufferedCSVReader::addValue(char *str_val, idx_t length, idx_t &column, vec
 		escape_positions.clear();
 		parse_data[row_entry] = StringVector::addString(v,  string_t(new_val.c_str()));
 	} else {
-		parse_data[row_entry] = StringVector::addString(v,  str_val);
+		// `length` is already known from parsing, so use the length-aware overload
+		// and avoid a strlen over every field (hot in CSV parsing).
+		parse_data[row_entry] = StringVector::addString(v, str_val, length);
 	}
 
 	// move to the next column

--- a/src/common/Hash.cpp
+++ b/src/common/Hash.cpp
@@ -3,6 +3,7 @@
 
 #include "bumblebee/common/Hash.hpp"
 
+#include <cstring>
 #include <functional>
 
 
@@ -66,9 +67,38 @@ uint32_t JenkinsOneAtATimeHash(const char *key, size_t length) {
     return hash;
 }
 
+// Word-at-a-time string hash (FNV-style accumulation with a strong finalizer).
+// Processes 8 bytes per iteration instead of 1, which dominates grouping/join
+// performance on string keys (e.g. URL GROUP BY). The hash value is used only
+// for bucketing and bloom filters — equality is always re-checked — so the
+// exact algorithm is a pure performance/distribution choice and cannot change
+// query results.
 hash_t Hash(const char *val, size_t size) {
-    auto hash_val = JenkinsOneAtATimeHash(val, size);
-    return Hash<uint32_t>(hash_val);
+    const uint64_t m = 0x9E3779B97F4A7C15ULL; // golden-ratio odd multiplier
+    uint64_t h = 0xcbf29ce484222325ULL ^ (size * m);
+    const char *p = val;
+    size_t n = size;
+    while (n >= 8) {
+        uint64_t k;
+        memcpy(&k, p, 8);
+        h ^= k;
+        h *= m;
+        h ^= h >> 29;
+        p += 8;
+        n -= 8;
+    }
+    if (n) {
+        // Read the remaining 1..7 bytes into a zero-initialised word.
+        uint64_t k = 0;
+        memcpy(&k, p, n);
+        h ^= k;
+        h *= m;
+    }
+    // Avalanche finalizer.
+    h ^= h >> 32;
+    h *= m;
+    h ^= h >> 29;
+    return h;
 }
 
 

--- a/src/common/Hash.cpp
+++ b/src/common/Hash.cpp
@@ -43,11 +43,6 @@ hash_t Hash(string val) {
 }
 
 template <>
-hash_t Hash(string_t val) {
-    return Hash(val.c_str(), val.size());
-}
-
-template <>
 hash_t Hash(char *val) {
     return Hash<const char *>(val);
 }

--- a/src/common/StringUtils.cpp
+++ b/src/common/StringUtils.cpp
@@ -216,14 +216,6 @@ bool StringUtils::characterIsSpace(char c) {
 	return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
 }
 
-bool StringUtils::characterIsDigit(char c) {
-	return c >= '0' && c <= '9';
-}
-
-bool StringUtils::characterIsNewline(char c) {
-	return c == '\n' || c == '\r';
-}
-
 string StringUtils::upper(const string &str) {
 	string copy(str);
 	transform(copy.begin(), copy.end(), copy.begin(), [](unsigned char c) { return std::toupper(c); });

--- a/src/common/parquet/ColumnReader.cpp
+++ b/src/common/parquet/ColumnReader.cpp
@@ -178,28 +178,50 @@ void ColumnReader::prepareRead(parquet_filter_t &filter) {
 void ColumnReader::preparePage(idx_t compressed_page_size, idx_t uncompressed_page_size) {
 	auto &trans = (ThriftFileTransport &)*protocol_->getTransport();
 
-	block_ = std::make_shared<ResizeableBuffer>(reader_.allocator_, compressed_page_size + 1);
-	trans.read((uint8_t *)block_->ptr_, compressed_page_size);
+	// Decompressing every page into a freshly allocated buffer faults in a new
+	// OS page every 4 KiB of output -> millions of minor page faults dominate
+	// scan system time and serialize threads. Reuse buffers across pages so
+	// their pages stay resident:
+	//  - the compressed read buffer is pure transient input to the decompressor
+	//    (never referenced afterwards) so it is always reused;
+	//  - the decompressed buffer is referenced zero-copy by string columns, so
+	//    it is only reused when no output chunk still holds it (use_count == 1);
+	//    otherwise a fresh buffer is allocated, preserving the referenced data.
+	if (chunk_->meta_data.codec == CompressionCodec::UNCOMPRESSED) {
+		// uncompressed: the read buffer is the data buffer (referenced) -> guard
+		if (block_ && block_.use_count() == 1) {
+			block_->resize(reader_.allocator_, compressed_page_size + 1);
+		} else {
+			block_ = std::make_shared<ResizeableBuffer>(reader_.allocator_, compressed_page_size + 1);
+		}
+		trans.read((uint8_t *)block_->ptr_, compressed_page_size);
+		return;
+	}
+
+	compressedBuffer_.resize(reader_.allocator_, compressed_page_size + 1);
+	trans.read((uint8_t *)compressedBuffer_.ptr_, compressed_page_size);
 
 	std::shared_ptr<ResizeableBuffer> unpacked_block;
-	if (chunk_->meta_data.codec != CompressionCodec::UNCOMPRESSED) {
+	if (block_ && block_.use_count() == 1) {
+		// safe to reuse: no live output chunk references the previous page
+		block_->resize(reader_.allocator_, uncompressed_page_size + 1);
+		unpacked_block = block_;
+	} else {
 		unpacked_block = std::make_shared<ResizeableBuffer>(reader_.allocator_, uncompressed_page_size + 1);
 	}
 
 	switch (chunk_->meta_data.codec) {
-	case CompressionCodec::UNCOMPRESSED:
-		break;
 	case CompressionCodec::GZIP: {
 		MiniZStream s;
 
-		s.decompress((const char *) block_->ptr_, compressed_page_size, (char *)unpacked_block->ptr_,
+		s.decompress((const char *) compressedBuffer_.ptr_, compressed_page_size, (char *)unpacked_block->ptr_,
 		             uncompressed_page_size);
 		block_ = std::move(unpacked_block);
 
 		break;
 	}
 	case CompressionCodec::SNAPPY: {
-		auto res = snappy::RawUncompress((const char *)block_->ptr_, compressed_page_size, (char *)unpacked_block->ptr_);
+		auto res = snappy::RawUncompress((const char *)compressedBuffer_.ptr_, compressed_page_size, (char *)unpacked_block->ptr_);
 		if (!res) {
 			ErrorHandler::errorGeneric("Decompression failure");
 		}
@@ -208,7 +230,7 @@ void ColumnReader::preparePage(idx_t compressed_page_size, idx_t uncompressed_pa
 	}
 	case CompressionCodec::ZSTD: {
 		auto res = ZSTD_decompress((char *)unpacked_block->ptr_, uncompressed_page_size,
-		                                        (const char *)block_->ptr_, compressed_page_size);
+		                                        (const char *)compressedBuffer_.ptr_, compressed_page_size);
 		if (ZSTD_isError(res) || res != (size_t)uncompressed_page_size) {
 			ErrorHandler::errorGeneric("ZSTD Decompression failure");
 		}

--- a/src/common/parquet/ColumnReader.cpp
+++ b/src/common/parquet/ColumnReader.cpp
@@ -160,7 +160,10 @@ void ColumnReader::prepareRead(parquet_filter_t &filter) {
 	PageHeader page_hdr;
 	page_hdr.read(protocol_);
 
-	preparePage(page_hdr.compressed_page_size, page_hdr.uncompressed_page_size);
+	// Dictionary pages are moved into dict_ and live for the whole row group, so
+	// they are allocated fresh; only per-page data buffers are drawn from the pool.
+	const bool poolable = page_hdr.type != PageType::DICTIONARY_PAGE;
+	preparePage(page_hdr.compressed_page_size, page_hdr.uncompressed_page_size, poolable);
 
 	switch (page_hdr.type) {
 		case PageType::DATA_PAGE_V2:
@@ -175,7 +178,22 @@ void ColumnReader::prepareRead(parquet_filter_t &filter) {
 	}
 }
 
-void ColumnReader::preparePage(idx_t compressed_page_size, idx_t uncompressed_page_size) {
+std::shared_ptr<ResizeableBuffer> ColumnReader::acquireDecompressed(idx_t size) {
+	// Reuse a pooled buffer no longer referenced by any live output chunk. block_
+	// has been reset by the time this runs, so use_count == 1 means only the pool
+	// entry holds it and no zero-copy reference into it is still alive.
+	for (auto &buf : decompressedPool_) {
+		if (buf.use_count() == 1) {
+			buf->resize(reader_.allocator_, size);
+			return buf;
+		}
+	}
+	auto buf = std::make_shared<ResizeableBuffer>(reader_.allocator_, size);
+	decompressedPool_.push_back(buf);
+	return buf;
+}
+
+void ColumnReader::preparePage(idx_t compressed_page_size, idx_t uncompressed_page_size, bool poolable) {
 	auto &trans = (ThriftFileTransport &)*protocol_->getTransport();
 
 	// Decompressing every page into a freshly allocated buffer faults in a new
@@ -184,16 +202,14 @@ void ColumnReader::preparePage(idx_t compressed_page_size, idx_t uncompressed_pa
 	// their pages stay resident:
 	//  - the compressed read buffer is pure transient input to the decompressor
 	//    (never referenced afterwards) so it is always reused;
-	//  - the decompressed buffer is referenced zero-copy by string columns, so
-	//    it is only reused when no output chunk still holds it (use_count == 1);
-	//    otherwise a fresh buffer is allocated, preserving the referenced data.
+	//  - decompressed data-page buffers are referenced zero-copy by string
+	//    columns, so they are drawn from a pool that hands back only buffers no
+	//    live chunk still holds; dictionary pages (poolable == false) live for the
+	//    whole row group and are allocated fresh.
 	if (chunk_->meta_data.codec == CompressionCodec::UNCOMPRESSED) {
-		// uncompressed: the read buffer is the data buffer (referenced) -> guard
-		if (block_ && block_.use_count() == 1) {
-			block_->resize(reader_.allocator_, compressed_page_size + 1);
-		} else {
-			block_ = std::make_shared<ResizeableBuffer>(reader_.allocator_, compressed_page_size + 1);
-		}
+		// uncompressed: the read buffer is the data buffer (referenced)
+		block_ = poolable ? acquireDecompressed(compressed_page_size + 1)
+		                  : std::make_shared<ResizeableBuffer>(reader_.allocator_, compressed_page_size + 1);
 		trans.read((uint8_t *)block_->ptr_, compressed_page_size);
 		return;
 	}
@@ -201,14 +217,9 @@ void ColumnReader::preparePage(idx_t compressed_page_size, idx_t uncompressed_pa
 	compressedBuffer_.resize(reader_.allocator_, compressed_page_size + 1);
 	trans.read((uint8_t *)compressedBuffer_.ptr_, compressed_page_size);
 
-	std::shared_ptr<ResizeableBuffer> unpacked_block;
-	if (block_ && block_.use_count() == 1) {
-		// safe to reuse: no live output chunk references the previous page
-		block_->resize(reader_.allocator_, uncompressed_page_size + 1);
-		unpacked_block = block_;
-	} else {
-		unpacked_block = std::make_shared<ResizeableBuffer>(reader_.allocator_, uncompressed_page_size + 1);
-	}
+	std::shared_ptr<ResizeableBuffer> unpacked_block =
+	    poolable ? acquireDecompressed(uncompressed_page_size + 1)
+	             : std::make_shared<ResizeableBuffer>(reader_.allocator_, uncompressed_page_size + 1);
 
 	switch (chunk_->meta_data.codec) {
 	case CompressionCodec::GZIP: {

--- a/src/common/parquet/ParquetReader.cpp
+++ b/src/common/parquet/ParquetReader.cpp
@@ -26,6 +26,10 @@
 #include "bumblebee/common/types/Decimal.hpp"
 #include "bumblebee/planner/filter/TableFilter.hpp"
 
+#include <chrono>
+#include <mutex>
+#include <unordered_map>
+
 namespace bumblebee {
 
 
@@ -35,13 +39,30 @@ static std::unique_ptr<thrift::protocol::TProtocol> createThriftProtocol(Allocat
 	return make_unique<thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(std::move(transport));
 }
 
-static std::shared_ptr<ParquetFileMetadataCache> loadMetadata(Allocator &allocator, FileHandle &file_handle) {
+// Process-wide cache of parsed parquet footers, keyed by path + size + mtime. The footer
+// of a wide many-row-group file is megabytes of thrift and is otherwise parsed
+// several times per query (bind, max-thread estimation, scan); parsing once and
+// sharing the immutable FileMetaData removes that fixed per-query overhead, which
+// dominates the wall time of small/selective scans over large files.
+static std::mutex g_mdCacheMutex;
+static std::unordered_map<std::string, std::shared_ptr<ParquetFileMetadataCache>> g_mdCache;
 
+static std::shared_ptr<ParquetFileMetadataCache> loadMetadata(Allocator &allocator, FileHandle &file_handle) {
 	auto current_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
 	auto proto = createThriftProtocol(allocator, file_handle);
 	auto &transport = ((ThriftFileTransport &)*proto->getTransport());
 	auto file_size = transport.getSize();
+
+	// Cache lookup: identity is the path plus current size and mtime (a cheap
+	// change detector for read-mostly analytics files).
+	time_t mtime = file_handle.fileSystem_.getLastModifiedTime(file_handle);
+	std::string cacheKey = file_handle.path_ + ":" + std::to_string(file_size) + ":" + std::to_string((long long)mtime);
+	{
+		std::lock_guard<std::mutex> lock(g_mdCacheMutex);
+		auto it = g_mdCache.find(cacheKey);
+		if (it != g_mdCache.end()) return it->second;
+	}
 	if (file_size < 12) {
 		ErrorHandler::errorGeneric(StringUtils::format("File '%s' too small to be a Parquet file", file_handle.path_));
 	}
@@ -67,7 +88,15 @@ static std::shared_ptr<ParquetFileMetadataCache> loadMetadata(Allocator &allocat
 
 	auto metadata = std::make_unique<format::FileMetaData>();
 	metadata->read(proto.get());
-	return make_shared<ParquetFileMetadataCache>(std::move(metadata), current_time);
+	auto cache = make_shared<ParquetFileMetadataCache>(std::move(metadata), current_time);
+	{
+		std::lock_guard<std::mutex> lock(g_mdCacheMutex);
+		// Bound the cache so a long-lived process scanning many distinct files
+		// cannot grow it without limit; footers are immutable so a coarse cap is fine.
+		if (g_mdCache.size() > 256) g_mdCache.clear();
+		g_mdCache[cacheKey] = cache;
+	}
+	return cache;
 }
 
 LogicalType ParquetReader::deriveLogicalType(const SchemaElement &s_ele) {

--- a/src/common/parquet/ParquetReader.cpp
+++ b/src/common/parquet/ParquetReader.cpp
@@ -468,6 +468,11 @@ bool ParquetReader::scanInternal(ParquetReaderScanState &state, DataChunk &resul
 			root_reader->getChildReader(file_col_idx)
 			    ->read(result.getSize(), filter_mask, define_ptr, repeat_ptr, result.data_[filter_col.first]);
 
+			// evaluate the filter on the freshly decoded values: rows that
+			// provably fail clear their mask bit, so the remaining columns can
+			// skip decoding them and the chunk is sliced before leaving the scan
+			filter_col.second->filterRows(result.data_[filter_col.first], this_output_chunk_rows, filter_mask);
+
 			need_to_read[filter_col.first] = false;
 
 		}

--- a/src/common/types/BumbleString.cpp
+++ b/src/common/types/BumbleString.cpp
@@ -24,75 +24,12 @@
 #include "bumblebee/common/ErrorHandler.hpp"
 
 namespace bumblebee {
-BumbleString::BumbleString(uint32_t len) {
-    value_.length = len;
-}
-
-BumbleString::BumbleString(const char *data): BumbleString(data, strlen(data)) {}
-
-BumbleString::BumbleString(const char *data, uint32_t len) {
-    value_.length = len;
-    if (isInlined()) {
-        // store the data in prefix
-        // +1 for string termination
-        memcpy(value_.prefix, data, len * sizeof(char));
-        value_.prefix[len] = '\0';
-        return;
-    }
-    memcpy(value_.prefix, data, PREFIX_LENGTH * sizeof(char));
-    value_.prefix[PREFIX_LENGTH] = '\0';
-    value_.ptr = (char *)(data);
-}
-
-BumbleString::BumbleString(const BumbleString &other): BumbleString(other.c_str(), other.size()) {}
-
-
-char * BumbleString::getDataWriteable() const {
-    if (isInlined())
-        return (char*)value_.prefix;
-    return value_.ptr;
-}
 
 string BumbleString::getString() const {
     const char* data = getDataUnsafe();
 
     string result(data, size());
     return result;
-}
-
-
-bool BumbleString::operator<(const BumbleString &r) const {
-    // compare the data
-    auto left_length = size();
-    auto right_length = r.size();
-    auto min_length = std::min(left_length, right_length);
-    auto memcmp_res = memcmp(getDataUnsafe(), r.getDataUnsafe(), min_length);
-    return memcmp_res < 0 || (memcmp_res == 0 && left_length < right_length);
-
-}
-
-bool BumbleString::operator>(const BumbleString &r) const {
-    // compare the data: length-aware memcmp, consistent with operator<. strcmp is unusable here
-    // because byte-comparable sort keys contain embedded NUL bytes (which terminate strcmp early).
-    auto left_length = size();
-    auto right_length = r.size();
-    auto min_length = std::min(left_length, right_length);
-    auto memcmp_res = memcmp(getDataUnsafe(), r.getDataUnsafe(), min_length);
-    return memcmp_res > 0 || (memcmp_res == 0 && left_length > right_length);
-}
-
-bool BumbleString::operator==(const BumbleString &r) const {
-    auto left_length = size();
-    auto right_length = r.size();
-    return left_length == right_length && memcmp(getDataUnsafe(), r.getDataUnsafe(), left_length) == 0;
-}
-
-const char * BumbleString::c_str() const {
-    return getDataUnsafe();
-}
-
-bool BumbleString::isInlined( uint32_t len) {
-    return len <= PREFIX_LENGTH;
 }
 
 }

--- a/src/common/types/Graph.cpp
+++ b/src/common/types/Graph.cpp
@@ -20,7 +20,6 @@
 
 #include <iostream>
 #include <stack>
-#include <__ostream/basic_ostream.h>
 
 #include "bumblebee/common/Log.hpp"
 

--- a/src/common/vector_operations/CreateSortKey.cpp
+++ b/src/common/vector_operations/CreateSortKey.cpp
@@ -330,9 +330,37 @@ static void prepareSortData(Vector &result, idx_t size, SortKeyLengthInfo &keyLe
     BB_ASSERT(result.getType() == PhysicalType::STRING);
 
     auto result_data = FlatVector::getData<string_t>(result);
+
+    // Fast path: fixed-width keys (no variable-length sort columns) that are not
+    // inlined (> PREFIX_LENGTH). Bulk-allocate one heap buffer per group of keys
+    // and carve equal-size slots instead of a per-row heap-string call. The
+    // string_t values reference the same heap with identical bytes, so
+    // comparisons and copies are byte-for-byte unchanged.
+    bool fixedWidth = true;
     for (idx_t r = 0; r < size; r++) {
-        auto blob_size = keyLengths.variable_[r] + keyLengths.constant_;
-        result_data[r] = StringVector::emptyString(result, blob_size);
+        if (keyLengths.variable_[r] != 0) { fixedWidth = false; break; }
+    }
+    const idx_t blob_size = keyLengths.constant_;
+    if (fixedWidth && blob_size > BumbleString::PREFIX_LENGTH) {
+        const idx_t stride = blob_size + 1;                 // +1 for null terminator
+        const idx_t perBuf = maxValue<idx_t>(1, (MINIMUM_HEAP_SIZE - 1) / stride);
+        idx_t r = 0;
+        while (r < size) {
+            idx_t batch = minValue<idx_t>(perBuf, size - r);
+            char *base = StringVector::emptyString(result, batch * stride).getDataWriteable();
+            for (idx_t k = 0; k < batch; ++k, ++r) {
+                char *p = base + k * stride;
+                p[blob_size] = '\0';
+                result_data[r] = string_t(p, (uint32_t)blob_size);
+                dataPtr[r] = (data_ptr_t)p;
+            }
+        }
+        return;
+    }
+
+    for (idx_t r = 0; r < size; r++) {
+        auto bs = keyLengths.variable_[r] + keyLengths.constant_;
+        result_data[r] = StringVector::emptyString(result, bs);
         dataPtr[r] = (data_ptr_t)result_data[r].getDataWriteable();
     }
 }

--- a/src/common/vector_operations/VectorCast.cpp
+++ b/src/common/vector_operations/VectorCast.cpp
@@ -170,6 +170,13 @@ bool numericCastSwitch(Vector &source, Vector &result, idx_t count, string *erro
             return vectorCastLoop<SRC, double, NumericTryCast>(source, result, count, errorMessage);
         case LogicalTypeId::STRING:
             return vectorStringCastLoop<SRC, string_t, StringTryCast>(source, result, count, errorMessage);
+        case LogicalTypeId::DATE:
+            // DATE is physically an int32 (days since epoch); a numeric value
+            // (e.g. a constant folded from parquet metadata) maps directly onto it.
+            return vectorCastLoop<SRC, int32_t, NumericTryCast>(source, result, count, errorMessage);
+        case LogicalTypeId::TIMESTAMP:
+            // TIMESTAMP is physically an int64 (microseconds since epoch).
+            return vectorCastLoop<SRC, int64_t, NumericTryCast>(source, result, count, errorMessage);
         case LogicalTypeId::DECIMAL: {
             switch (result.getType()) {
                 case PhysicalType::SMALLINT:

--- a/src/execution/AggregatePRLHashTable.cpp
+++ b/src/execution/AggregatePRLHashTable.cpp
@@ -22,6 +22,37 @@
 #include "bumblebee/function/AggregateFunction.hpp"
 
 namespace bumblebee{
+
+void AggregatePRLHashTable::internalizeStrings(Vector &payload, idx_t count) {
+    if (count == 0 || payload.getType() != PhysicalType::STRING)
+        return;
+    // flatten so we can rewrite the string_t entries in place
+    payload.normalify(count);
+    auto data = FlatVector::getData<string_t>(payload);
+
+    idx_t entry_sizes[STANDARD_VECTOR_SIZE];
+    data_ptr_t locations[STANDARD_VECTOR_SIZE];
+    bool any = false;
+    for (idx_t i = 0; i < count; i++) {
+        entry_sizes[i] = 0;
+        // NULL and inlined (<= prefix) strings carry their bytes in the string_t
+        // itself, so they need no external storage and stay valid as-is.
+        if (payload.rowIsValid(i) && !data[i].isInlined()) {
+            entry_sizes[i] = data[i].size();
+            any = true;
+        }
+    }
+    if (!any) return;
+
+    stringHeap_->build(count, locations, entry_sizes);
+    for (idx_t i = 0; i < count; i++) {
+        if (entry_sizes[i] == 0) continue;
+        const idx_t sz = data[i].size();
+        memcpy(locations[i], data[i].getDataUnsafe(), sz);
+        data[i] = string_t((const char *)locations[i], (uint32_t)sz);
+    }
+}
+
 AggregatePRLHashTable::AggregatePRLHashTable(BufferManager &manager, const vector<LogicalType> &types,
     idx_t capacity, bool resizable, const vector<AggregateFunction *> &functions): PRLHashTable(manager, types, capacity, resizable), functions_(functions) {
     layout_.initialize(types, functions);
@@ -49,9 +80,13 @@ void AggregatePRLHashTable::addChunk(Vector &hash, DataChunk &groups, DataChunk 
     // init the states (initStates already iterates all aggregate functions via layout)
     AggregateFunction::initStates(layout_, addresses, newGroupsSel, newGroupCount);
 
-    // now update the states
-    for (id_t i = 0;i<functions_.size();++i)
+    // now update the states. Internalize string payloads first so string
+    // aggregate states reference heap memory owned by this table, not the
+    // transient scan/decode buffer the payload points into.
+    for (id_t i = 0;i<functions_.size();++i) {
+        internalizeStrings(payload.data_[i], payload.getSize());
         AggregateFunction::updateStates(layout_, addresses,payload.data_[i],payload.getSize(), i );
+    }
 
 }
 
@@ -76,9 +111,11 @@ void AggregatePRLHashTable::addChunk(DataChunk &payload) {
     auto val = Value((uint64_t)payloadPtrs_.back());
     addresses.reference(val);
     BB_ASSERT(addresses.getVectorType() == VectorType::CONSTANT_VECTOR);
-    // update the payload with the first state
-    for (id_t i = 0;i<functions_.size();++i)
+    // update the payload with the first state (internalize strings first, see above)
+    for (id_t i = 0;i<functions_.size();++i) {
+        internalizeStrings(payload.data_[i], payload.getSize());
         AggregateFunction::updateStates(layout_, addresses,payload.data_[i],payload.getSize(), i );
+    }
 }
 
 void AggregatePRLHashTable::moveAndMergeStates(idx_t count, Vector &addresses, Vector &hashes) {

--- a/src/execution/AggregatePRLHashTable.cpp
+++ b/src/execution/AggregatePRLHashTable.cpp
@@ -82,6 +82,18 @@ void AggregatePRLHashTable::addChunk(DataChunk &payload) {
 }
 
 void AggregatePRLHashTable::moveAndMergeStates(idx_t count, Vector &addresses, Vector &hashes) {
+    if (count == 0) return;
+
+    // Fast path: fixed-width group keys -> merge at the tuple level. A new group is
+    // a single whole-tuple memcpy; a match combines states. The validity prefix sits
+    // at offset 0 (inside the compared key region) and NULL keys carry a canonical
+    // sentinel value, so memcmp of the key region is exact. Avoids the generic
+    // gather/scatter/init round trip that dominates high-cardinality combines.
+    if (layout_.allConstant() && !types_.empty()) {
+        moveAndMergeStatesFixed(count, addresses, hashes);
+        return;
+    }
+
     SelectionVector newGroupsSel(count);
     idx_t newGroupsCount = 0;
     auto groupAddresses = move(addresses, hashes, count, &newGroupsSel, newGroupsCount);
@@ -92,6 +104,59 @@ void AggregatePRLHashTable::moveAndMergeStates(idx_t count, Vector &addresses, V
 
     AggregateFunction::combineStates(layout_, addresses, groupAddresses, FlatVector::INCREMENTAL_SELECTION_VECTOR, count);
 
+}
+
+void AggregatePRLHashTable::moveAndMergeStatesFixed(idx_t count, Vector &addresses, Vector &hashes) {
+    // Ensure capacity for up to `count` brand-new groups so the probe below never
+    // needs to resize mid-loop (which would invalidate the directory pointer).
+    while (entries_ + count >= capacity_ ||
+           (float)(entries_ + count) / (float)capacity_ > LOAD_FACTOR) {
+        resize(capacity_ * 2);
+    }
+
+    auto srcPtrs = FlatVector::getData<data_ptr_t>(addresses);
+    auto hashPtrs = FlatVector::getData<hash_t>(hashes);
+    auto htEntries = (HTEntry64 *)hashesPtr_;
+    auto &offsets = layout_.getOffsets();
+    auto &aggregates = layout_.getAggregates();
+    const idx_t aggBase = layout_.columnCount();
+    // Key region = validity prefix (offset 0) + packed fixed-width group columns.
+    const idx_t keyEnd = offsets[types_.size() - 1] +
+                         getPhysicalTypeSize(types_[types_.size() - 1].getPhysicalType());
+
+    for (idx_t i = 0; i < count; ++i) {
+        auto src = srcPtrs[i];
+        const auto h = hashPtrs[i];
+        idx_t bucket = h & bitmask_;
+        while (true) {
+            auto &e = htEntries[bucket];
+            if (e.pageNum_ == 0) {
+                // empty bucket -> new group: copy the whole source tuple
+                if (payloadPageOffset_ == tuplesPerBlock_ || payload_.empty())
+                    newBlock();
+                auto dest = payloadPtrs_.back() + payloadPageOffset_ * tupleSize_;
+                memcpy(dest, src, tupleSize_);
+                e.pageNum_ = payload_.size();
+                e.pageOffset_ = payloadPageOffset_++;
+                e.hash_ = h;
+                entries_++;
+                break;
+            }
+            if (e.hash_ == h) {
+                auto dest = payloadPtrs_[e.pageNum_ - 1] + e.pageOffset_ * tupleSize_;
+                if (memcmp(src, dest, keyEnd) == 0) {
+                    // existing group: combine source state into the kept one
+                    idx_t a = aggBase;
+                    for (auto *aggr : aggregates) {
+                        aggr->combine_(src + offsets[a], dest + offsets[a]);
+                        ++a;
+                    }
+                    break;
+                }
+            }
+            bucket = (bucket + 1) & bitmask_;  // capacity is a power of two
+        }
+    }
 }
 
 void AggregatePRLHashTable::combine(AggregatePRLHashTable &other) {

--- a/src/execution/AggregatePRLHashTable.cpp
+++ b/src/execution/AggregatePRLHashTable.cpp
@@ -166,9 +166,14 @@ void AggregatePRLHashTable::moveAndMergeStatesFixed(idx_t count, Vector &address
         // hash and is the dominant cache miss when merging large HTs. Pull the
         // bucket for a later iteration into cache while we work on this one. The
         // pre-resize above keeps bitmask_/htEntries stable for the whole loop.
-        constexpr idx_t PREFETCH_DIST = 8;
-        if (i + PREFETCH_DIST < count)
+        constexpr idx_t PREFETCH_DIST = 32;
+        if (i + PREFETCH_DIST < count) {
             __builtin_prefetch(&htEntries[hashPtrs[i + PREFETCH_DIST] & bitmask_], 1, 0);
+            // The source tuple is read (memcpy for a new group / combine for a
+            // match) from a random local-HT address that scanRawEntries produced
+            // in directory order, so it is itself a cache miss; prefetch it too.
+            __builtin_prefetch(srcPtrs[i + PREFETCH_DIST], 0, 0);
+        }
         auto src = srcPtrs[i];
         const auto h = hashPtrs[i];
         idx_t bucket = h & bitmask_;

--- a/src/execution/AggregatePRLHashTable.cpp
+++ b/src/execution/AggregatePRLHashTable.cpp
@@ -125,6 +125,13 @@ void AggregatePRLHashTable::moveAndMergeStatesFixed(idx_t count, Vector &address
                          getPhysicalTypeSize(types_[types_.size() - 1].getPhysicalType());
 
     for (idx_t i = 0; i < count; ++i) {
+        // Software prefetch: the directory read below is a random access keyed by
+        // hash and is the dominant cache miss when merging large HTs. Pull the
+        // bucket for a later iteration into cache while we work on this one. The
+        // pre-resize above keeps bitmask_/htEntries stable for the whole loop.
+        constexpr idx_t PREFETCH_DIST = 8;
+        if (i + PREFETCH_DIST < count)
+            __builtin_prefetch(&htEntries[hashPtrs[i + PREFETCH_DIST] & bitmask_], 1, 0);
         auto src = srcPtrs[i];
         const auto h = hashPtrs[i];
         idx_t bucket = h & bitmask_;

--- a/src/execution/PRLHashTable.cpp
+++ b/src/execution/PRLHashTable.cpp
@@ -399,7 +399,14 @@ void PRLHashTable::findOrCreateGroupsInternal(Vector &hash, DataChunk &groups,
         idx_t newNoMatchCount = 0;
 
         // first figure out if it belongs to a full or empty group
+        constexpr idx_t PREFETCH_DIST = 8;
         for (idx_t i = 0; i < remainingEntries; i++) {
+
+            // Bounded-lookahead prefetch of the directory slot a few iterations
+            // ahead: htEntries[bucket] is a random-access cache miss for large
+            // tables. The directory is stable here (resize happened above).
+            if (i + PREFETCH_DIST < remainingEntries)
+                __builtin_prefetch(((HTEntry64*)hashesPtr_) + bucketsPtr[selVector.getIndex(i + PREFETCH_DIST)], 1, 0);
 
             idx_t index = selVector.getIndex(i);
             auto bucket = bucketsPtr[index];

--- a/src/execution/PRLHashTable.cpp
+++ b/src/execution/PRLHashTable.cpp
@@ -411,7 +411,7 @@ void PRLHashTable::findOrCreateGroupsInternal(Vector &hash, DataChunk &groups,
         idx_t newNoMatchCount = 0;
 
         // first figure out if it belongs to a full or empty group
-        constexpr idx_t PREFETCH_DIST = 8;
+        constexpr idx_t PREFETCH_DIST = 32;
         for (idx_t i = 0; i < remainingEntries; i++) {
 
             // Bounded-lookahead prefetch of the directory slot a few iterations

--- a/src/execution/PRLHashTable.cpp
+++ b/src/execution/PRLHashTable.cpp
@@ -298,7 +298,12 @@ void PRLHashTable::resize(idx_t size, bool initResize) {
     BB_ASSERT(size != 0 && (size & (size - 1)) == 0); // new size should be power of 2
     BB_ASSERT(resizable_ || initResize);
 
-    auto byteSize =  (size * sizeof(HTEntry64) > Storage::BLOCK_SIZE)? size * sizeof(HTEntry64): Storage::BLOCK_SIZE;
+    // The directory only needs `size` buckets (size * sizeof(HTEntry64) bytes).
+    // Allocate and zero exactly that much instead of rounding up to a full
+    // storage block: small per-partition tables (which grow 256 -> 512 -> 1024
+    // ...) previously memset a whole 256 KiB block on every resize even though
+    // only a few KiB were used, making memset a top hot spot in string GROUP BY.
+    auto byteSize = size * sizeof(HTEntry64);
     auto hashes = bufferManager_.allocate(byteSize);
     auto hashesPtr = hashes->ptr();
     memset(hashesPtr, 0, byteSize);

--- a/src/execution/PRLHashTable.cpp
+++ b/src/execution/PRLHashTable.cpp
@@ -303,8 +303,15 @@ void PRLHashTable::resize(idx_t size, bool initResize) {
     // storage block: small per-partition tables (which grow 256 -> 512 -> 1024
     // ...) previously memset a whole 256 KiB block on every resize even though
     // only a few KiB were used, making memset a top hot spot in string GROUP BY.
+    // The block buffer manager requires every managed buffer to be at least one
+    // storage block, so floor the allocation at BLOCK_SIZE while still zeroing only
+    // the bytes the directory actually uses (`byteSize`) - this keeps the memset
+    // optimization above for small tables without violating that invariant. For
+    // directories larger than a block (the common case for big GROUP BYs) the
+    // allocation is unchanged.
     auto byteSize = size * sizeof(HTEntry64);
-    auto hashes = bufferManager_.allocate(byteSize);
+    auto allocSize = maxValue<idx_t>(byteSize, (idx_t)Storage::BLOCK_SIZE);
+    auto hashes = bufferManager_.allocate(allocSize);
     auto hashesPtr = hashes->ptr();
     memset(hashesPtr, 0, byteSize);
 

--- a/src/execution/PartitionedAggHT.cpp
+++ b/src/execution/PartitionedAggHT.cpp
@@ -83,6 +83,14 @@ void PartitionedAggHT::initialize(DataChunk &chunk) {
             BB_ASSERT(col < types_.size());
             groupColsType_.push_back(types_[col]);
         }
+        // Does any aggregate keep variable-length (heap-referencing) state? Only
+        // string-valued aggregates (MIN/MAX over VARCHAR) store a string_t that
+        // points into the local HT's string heap; for those we must carry that
+        // heap over when combining thread-local HTs. A STRING payload column is a
+        // safe superset of that condition.
+        aggStateVarlen_ = false;
+        for (auto& t : payloadColsType_)
+            if (t.getPhysicalType() == PhysicalType::STRING) { aggStateVarlen_ = true; break; }
     }
     initialized_ = true;
 }
@@ -230,9 +238,18 @@ void PartitionedAggHT::combineLocalHt(agg_ht_ptr_t localHt) {
 
     // Transfer string heap from local HT to each partition that received entries,
     // so aggregate states referencing variable-length data remain valid.
-    for (idx_t p = 0; p < partitions_; ++p) {
-        if (pAggHts_[p])
-            pAggHts_[p]->mergeStringHeap(*localHt);
+    //
+    // Group-key strings are re-scattered into each partition's own heap by
+    // moveAndMergeStates (generic path), so the local heap's copy of them is dead
+    // weight after the merge. Only variable-length aggregate *state* (string
+    // MIN/MAX) still points into the local heap. When no such state exists, skip
+    // the merge entirely and let the local heap be freed with the local HT - this
+    // avoids retaining a full duplicate of every distinct key string.
+    if (aggStateVarlen_) {
+        for (idx_t p = 0; p < partitions_; ++p) {
+            if (pAggHts_[p])
+                pAggHts_[p]->mergeStringHeap(*localHt);
+        }
     }
 }
 

--- a/src/execution/PhysicalAtom.cpp
+++ b/src/execution/PhysicalAtom.cpp
@@ -114,10 +114,6 @@ idx_t PhysicalAtom::getMaxThreads() const {
 void PhysicalAtom::setMaxThreads(idx_t threads) const {
 }
 
-idx_t PhysicalAtom::getEstimatedCardinality() const {
-    return getMaxThreads() * MORSEL_SIZE;
-}
-
 bool GlobalPhysicalAtomState::getNextBucket(idx_t &start, idx_t &end, idx_t &current, vector<idx_t> &size) {
     if (current >= size.size()) {
         return false;

--- a/src/execution/PhysicalAtom.cpp
+++ b/src/execution/PhysicalAtom.cpp
@@ -114,6 +114,10 @@ idx_t PhysicalAtom::getMaxThreads() const {
 void PhysicalAtom::setMaxThreads(idx_t threads) const {
 }
 
+idx_t PhysicalAtom::getEstimatedCardinality() const {
+    return getMaxThreads() * MORSEL_SIZE;
+}
+
 bool GlobalPhysicalAtomState::getNextBucket(idx_t &start, idx_t &end, idx_t &current, vector<idx_t> &size) {
     if (current >= size.size()) {
         return false;

--- a/src/execution/RowLayoutJoinHashTable.cpp
+++ b/src/execution/RowLayoutJoinHashTable.cpp
@@ -137,11 +137,18 @@ void addNewEntriesInHash(idx_t idx, vector<buffer_handle_ptr_t>& payload, idx_t 
     idx_t page_nr = idx / tuplesPerBlock;
     idx_t page_offset = idx % tuplesPerBlock;
 
+    constexpr idx_t PREFETCH_DIST = 8;
     for (; page_nr < payload.size(); ++page_nr) {
         auto payload_chunk_ptr = payload[page_nr]->ptr() + page_offset * tupleSize;
         auto this_entries = minValue(tuplesPerBlock - page_offset, apply_entries);
         auto end = payload_chunk_ptr + this_entries * tupleSize;
         for (data_ptr_t ptr = payload_chunk_ptr; ptr < end; ptr += tupleSize) {
+            // Prefetch the directory slot for a later row while we insert this one:
+            // hashEntries[bucket] is a random-access write and the dominant cache
+            // miss when building a large join hash table.
+            auto pf = ptr + PREFETCH_DIST * tupleSize;
+            if (pf < end)
+                __builtin_prefetch(&hashEntries[load<hash_t>(pf + hashOffset) & bitmask], 1, 0);
             auto hash = load<hash_t>(ptr+hashOffset);
             auto bucket = hash & bitmask;
             while (hashEntries[bucket].pageNum_ != 0) {
@@ -258,7 +265,12 @@ void findAddresses(idx_t capacity, idx_t tupleSize, data_ptr_t hashesPtr, vector
     if (!sel)
         sel = &FlatVector::INCREMENTAL_SELECTION_VECTOR;
 
+    constexpr idx_t PREFETCH_DIST = 8;
     for (idx_t i=0; i < size; ++i) {
+        // Prefetch the directory slot a few probes ahead; the bucket is already
+        // computed, and the htEntry read below is the dominant cache miss.
+        if (i + PREFETCH_DIST < size)
+            __builtin_prefetch(((HTEntry64*)hashesPtr) + bucketPtr[sel->getIndex(i + PREFETCH_DIST)], 0, 0);
         auto idx = sel->getIndex(i);
         auto hash = hashPtr[idx];
         auto bucket = bucketPtr[idx];

--- a/src/execution/TopNHeap.cpp
+++ b/src/execution/TopNHeap.cpp
@@ -35,6 +35,62 @@ TopNHeap::TopNHeap(const vector<LogicalType> &payloadTypes,const vector<ColModif
         sortCols_.push_back(colModifier.col_);
         sortColTypes_.push_back(payloadTypes_[colModifier.col_]);
     }
+
+    // Enable the first-column prefilter only for integer first sort columns,
+    // where a monotonic order-code can be derived cheaply (covers counts,
+    // dates/timestamps and integer keys). Other types use the full path.
+    if (!sortColTypes_.empty()) {
+        firstColPhysType_ = sortColTypes_[0].getPhysicalType();
+        desc0_ = modifiers_[0].order_type == OrderType::DESCENDING;
+        switch (firstColPhysType_) {
+            case PhysicalType::TINYINT:  case PhysicalType::SMALLINT:
+            case PhysicalType::INTEGER:  case PhysicalType::BIGINT:
+            case PhysicalType::UTINYINT: case PhysicalType::USMALLINT:
+            case PhysicalType::UINTEGER: case PhysicalType::UBIGINT:
+                prefilterEnabled_ = true;
+                break;
+            default:
+                prefilterEnabled_ = false;
+        }
+    }
+}
+
+uint64_t TopNHeap::orderCodeAt(Vector &v, idx_t i) const {
+    // Map the value to a uint64 that preserves the column's sort order, so that
+    // a smaller code means "sorts earlier" (better). Signed types are offset by
+    // the sign bit; DESC inverts the code.
+    static constexpr uint64_t SIGN = 0x8000000000000000ull;
+    uint64_t code;
+    switch (firstColPhysType_) {
+        case PhysicalType::TINYINT:  code = (uint64_t)(int64_t)FlatVector::getData<int8_t>(v)[i] ^ SIGN; break;
+        case PhysicalType::SMALLINT: code = (uint64_t)(int64_t)FlatVector::getData<int16_t>(v)[i] ^ SIGN; break;
+        case PhysicalType::INTEGER:  code = (uint64_t)(int64_t)FlatVector::getData<int32_t>(v)[i] ^ SIGN; break;
+        case PhysicalType::BIGINT:   code = (uint64_t)FlatVector::getData<int64_t>(v)[i] ^ SIGN; break;
+        case PhysicalType::UTINYINT: code = (uint64_t)FlatVector::getData<uint8_t>(v)[i]; break;
+        case PhysicalType::USMALLINT:code = (uint64_t)FlatVector::getData<uint16_t>(v)[i]; break;
+        case PhysicalType::UINTEGER: code = (uint64_t)FlatVector::getData<uint32_t>(v)[i]; break;
+        case PhysicalType::UBIGINT:  code = (uint64_t)FlatVector::getData<uint64_t>(v)[i]; break;
+        default: return 0; // unreachable when prefilterEnabled_
+    }
+    return desc0_ ? ~code : code;
+}
+
+bool TopNHeap::chunkCanContribute(DataChunk &input) const {
+    // Only meaningful once the heap is full and we can derive a threshold.
+    if (!prefilterEnabled_ || heap_.size() < heapSize_) return true;
+    const TopNEntry &front = heap_.front();
+    if (!front.firstValid_) return true;            // NULL threshold: be conservative
+    const uint64_t thresh = front.firstCode_;
+    Vector &col = input.data_[sortCols_[0]];
+    const idx_t n = input.getSize();
+    for (idx_t i = 0; i < n; ++i) {
+        if (!col.rowIsValid(i)) return true;        // NULL row: cannot rule out
+        // A row can only enter the heap if its first-column code is <= the
+        // threshold's (a strictly larger code sorts strictly after the worst
+        // kept entry on the dominant column, so it can never qualify).
+        if (orderCodeAt(col, i) <= thresh) return true;
+    }
+    return false;
 }
 
 void TopNHeap::sink(DataChunk &input) {
@@ -42,6 +98,10 @@ void TopNHeap::sink(DataChunk &input) {
     BB_ASSERT(input.getSize() <= STANDARD_VECTOR_SIZE);
     // we need to normalify as we will copy only a subset of rows
     input.normalify();
+
+    // Fast path: when the heap is full, skip building sort keys for an entire
+    // chunk whose rows are all provably worse than the current threshold.
+    if (!chunkCanContribute(input)) return;
 
     BB_ASSERT(keyStrings_.getCapacity() >= STANDARD_VECTOR_SIZE);
     DataChunk sortChunk;
@@ -51,6 +111,7 @@ void TopNHeap::sink(DataChunk &input) {
     keyStrings_.setCardinality(input.getSize());
 
     auto dataPtr = FlatVector::getData<string_t>(keyStrings_.data_[0]);
+    Vector &firstCol = input.data_[sortCols_[0]];
     idx_t count = 0;
     idx_t idx = heapData_.getSize();
     for (idx_t i = 0; i < input.getSize(); ++i) {
@@ -58,6 +119,10 @@ void TopNHeap::sink(DataChunk &input) {
         if (!shouldAddToHeap(key))
             continue;
         TopNEntry entry{.sortKey_ = key, .index_ = idx++};
+        if (prefilterEnabled_) {
+            entry.firstValid_ = firstCol.rowIsValid(i);
+            if (entry.firstValid_) entry.firstCode_ = orderCodeAt(firstCol, i);
+        }
         dataToInsert_.setIndex(count++, i);
         addEntryToHeap(entry);
     }
@@ -66,8 +131,6 @@ void TopNHeap::sink(DataChunk &input) {
     // for all the entry added we need to copy the strings and the payload
     heapData_.append(keyStrings_, true, &dataToInsert_, count);
     heapPayload_.append(input, true, &dataToInsert_, count);
-
-    int x = 0;
 }
 
 void TopNHeap::reduce(bool force) {
@@ -128,7 +191,9 @@ void TopNHeap::combine(TopNHeap &other) {
 
         dataToInsert_.setIndex(count++, other.heap_[i].index_);
 
-        TopNEntry entry{.sortKey_ = key, .index_ = idx++};
+        TopNEntry entry{.sortKey_ = key, .index_ = idx++,
+                        .firstCode_ = other.heap_[i].firstCode_,
+                        .firstValid_ = other.heap_[i].firstValid_};
         addEntryToHeap(entry);
     }
 

--- a/src/execution/TopNHeap.cpp
+++ b/src/execution/TopNHeap.cpp
@@ -22,7 +22,8 @@ namespace bumblebee{
 
 TopNHeap::TopNHeap(const vector<LogicalType> &payloadTypes,const vector<ColModifier> &modifiers, idx_t limit): payloadTypes_(payloadTypes),
     heapSize_(limit),
-    dataToInsert_(STANDARD_VECTOR_SIZE){
+    dataToInsert_(STANDARD_VECTOR_SIZE),
+    candSel_(STANDARD_VECTOR_SIZE){
     BB_ASSERT(limit <= STANDARD_VECTOR_SIZE);
     vector<PhysicalType> types {PhysicalType::STRING};
     heapData_.initialize(types);
@@ -75,47 +76,19 @@ uint64_t TopNHeap::orderCodeAt(Vector &v, idx_t i) const {
     return desc0_ ? ~code : code;
 }
 
-bool TopNHeap::chunkCanContribute(DataChunk &input) const {
-    // Only meaningful once the heap is full and we can derive a threshold.
-    if (!prefilterEnabled_ || heap_.size() < heapSize_) return true;
-    const TopNEntry &front = heap_.front();
-    if (!front.firstValid_) return true;            // NULL threshold: be conservative
-    const uint64_t thresh = front.firstCode_;
-    Vector &col = input.data_[sortCols_[0]];
-    const idx_t n = input.getSize();
-    for (idx_t i = 0; i < n; ++i) {
-        if (!col.rowIsValid(i)) return true;        // NULL row: cannot rule out
-        // A row can only enter the heap if its first-column code is <= the
-        // threshold's (a strictly larger code sorts strictly after the worst
-        // kept entry on the dominant column, so it can never qualify).
-        if (orderCodeAt(col, i) <= thresh) return true;
-    }
-    return false;
-}
-
-void TopNHeap::sink(DataChunk &input) {
-    BB_ASSERT(keyStrings_.columnCount() == 1 && keyStrings_.data_[0].getType() == PhysicalType::STRING);
-    BB_ASSERT(input.getSize() <= STANDARD_VECTOR_SIZE);
-    // we need to normalify as we will copy only a subset of rows
-    input.normalify();
-
-    // Fast path: when the heap is full, skip building sort keys for an entire
-    // chunk whose rows are all provably worse than the current threshold.
-    if (!chunkCanContribute(input)) return;
-
-    BB_ASSERT(keyStrings_.getCapacity() >= STANDARD_VECTOR_SIZE);
+void TopNHeap::sinkChunk(DataChunk &chunk) {
     DataChunk sortChunk;
     sortChunk.initializeEmpty(sortColTypes_);
-    sortChunk.reference(input, sortCols_);
+    sortChunk.reference(chunk, sortCols_);
     CreateSortKey::createSortKey(sortChunk, modifiers_, keyStrings_.data_[0]);
-    keyStrings_.setCardinality(input.getSize());
+    keyStrings_.setCardinality(chunk.getSize());
 
     auto dataPtr = FlatVector::getData<string_t>(keyStrings_.data_[0]);
-    Vector &firstCol = input.data_[sortCols_[0]];
+    Vector &firstCol = chunk.data_[sortCols_[0]];
     idx_t count = 0;
     idx_t idx = heapData_.getSize();
-    for (idx_t i = 0; i < input.getSize(); ++i) {
-        auto& key = dataPtr[i];
+    for (idx_t i = 0; i < chunk.getSize(); ++i) {
+        auto &key = dataPtr[i];
         if (!shouldAddToHeap(key))
             continue;
         TopNEntry entry{.sortKey_ = key, .index_ = idx++};
@@ -128,9 +101,45 @@ void TopNHeap::sink(DataChunk &input) {
     }
 
     if (!count) return;
-    // for all the entry added we need to copy the strings and the payload
+    // copy the strings and payload only for the rows that entered the heap
     heapData_.append(keyStrings_, true, &dataToInsert_, count);
-    heapPayload_.append(input, true, &dataToInsert_, count);
+    heapPayload_.append(chunk, true, &dataToInsert_, count);
+}
+
+void TopNHeap::sink(DataChunk &input) {
+    BB_ASSERT(keyStrings_.columnCount() == 1 && keyStrings_.data_[0].getType() == PhysicalType::STRING);
+    BB_ASSERT(input.getSize() <= STANDARD_VECTOR_SIZE);
+    BB_ASSERT(keyStrings_.getCapacity() >= STANDARD_VECTOR_SIZE);
+    // we need to normalify as we will copy only a subset of rows
+    input.normalify();
+
+    const idx_t n = input.getSize();
+    // Fast path: once the heap is full, only rows whose first-column order-code
+    // is <= the threshold (the worst kept entry) can possibly qualify. A row with
+    // a strictly larger code sorts strictly after the threshold on the dominant
+    // column and can never enter the heap, so we skip building its sort key.
+    if (prefilterEnabled_ && heap_.size() >= heapSize_ && heap_.front().firstValid_) {
+        const uint64_t thresh = heap_.front().firstCode_;
+        Vector &col = input.data_[sortCols_[0]];
+        idx_t nc = 0;
+        for (idx_t i = 0; i < n; ++i) {
+            // NULL rows cannot be ruled out cheaply -> keep as candidates
+            if (!col.rowIsValid(i) || orderCodeAt(col, i) <= thresh)
+                candSel_.setIndex(nc++, i);
+        }
+        if (nc == 0) return;                 // whole chunk pruned
+        if (nc < n) {
+            DataChunk cand;
+            cand.initAndReference(input);
+            cand.slice(candSel_, nc);
+            cand.normalify();
+            sinkChunk(cand);
+            return;
+        }
+        // nc == n: every row is a candidate, fall through to the full path
+    }
+
+    sinkChunk(input);
 }
 
 void TopNHeap::reduce(bool force) {

--- a/src/execution/atom/external/PhysicalPredFunction.cpp
+++ b/src/execution/atom/external/PhysicalPredFunction.cpp
@@ -60,6 +60,14 @@ idx_t PhysicalPredFunction::getMaxThreads() const {
     return predFunction_->maxThreadFunction_(context_, bindData_.get());
 }
 
+idx_t PhysicalPredFunction::getEstimatedCardinality() const {
+    // Prefer a real row-count estimate (e.g. from parquet metadata) when the
+    // function provides one; otherwise fall back to the coarse base estimate.
+    if (predFunction_->cardinalityFunction_)
+        return predFunction_->cardinalityFunction_(context_, bindData_.get());
+    return PhysicalAtom::getEstimatedCardinality();
+}
+
 bool PhysicalPredFunction::isSource() const {
     return true;
 }

--- a/src/execution/atom/external/PhysicalPredFunction.cpp
+++ b/src/execution/atom/external/PhysicalPredFunction.cpp
@@ -60,14 +60,6 @@ idx_t PhysicalPredFunction::getMaxThreads() const {
     return predFunction_->maxThreadFunction_(context_, bindData_.get());
 }
 
-idx_t PhysicalPredFunction::getEstimatedCardinality() const {
-    // Prefer a real row-count estimate (e.g. from parquet metadata) when the
-    // function provides one; otherwise fall back to the coarse base estimate.
-    if (predFunction_->cardinalityFunction_)
-        return predFunction_->cardinalityFunction_(context_, bindData_.get());
-    return PhysicalAtom::getEstimatedCardinality();
-}
-
 bool PhysicalPredFunction::isSource() const {
     return true;
 }

--- a/src/function/predicate/ReadParquet.cpp
+++ b/src/function/predicate/ReadParquet.cpp
@@ -226,6 +226,15 @@ static void readParquetFunction(ClientContext &context, const FunctionData *bind
 		// exhausted
 		data.finished_ = true;
 		data.readChunk_.data_.clear();
+		// Release this morsel's reader as soon as it is drained. The column readers
+		// own the decompressed parquet page buffers (one ~page-sized buffer per
+		// scanned column), which are no longer referenced once the output chunk
+		// above has been cleared. Holding them until the whole pipeline tears down
+		// makes scan memory grow with the number of row groups (one morsel each);
+		// freeing here bounds it to the morsels actively being scanned.
+		data.readerState_.rootReader_.reset();
+		data.readerState_.fileHandle_.reset();
+		data.readerState_.thriftFileProto_.reset();
 	}else {
 		// every column of the (narrow) scan chunk is selected, reset them all
 		data.readChunk_.reset();

--- a/src/function/predicate/ReadParquet.cpp
+++ b/src/function/predicate/ReadParquet.cpp
@@ -26,6 +26,7 @@ idx_t ReadParquetData::getMaxThread() {
 	ParquetOptions options;
 
 	filesToProcess_.clear();
+	totalRows_ = 0;
 	for (idx_t fileIdx = 0; fileIdx < files_.size(); ++fileIdx) {
 		ParquetReader reader(context_, files_[fileIdx], options);
 		auto metadata = reader.getFileMetadata();
@@ -35,6 +36,7 @@ idx_t ReadParquetData::getMaxThread() {
 
 		for (idx_t rgIdx = 0; rgIdx < metadata->row_groups.size(); ++rgIdx) {
 			const auto rows = metadata->row_groups[rgIdx].num_rows;
+			totalRows_ += rows;
 
 			// If adding this group would exceed the morsel and we already have something, flush.
 			if (currentRows > 0 && currentRows + rows > MORSEL_SIZE) {
@@ -54,6 +56,12 @@ idx_t ReadParquetData::getMaxThread() {
 	}
 
 	return filesToProcess_.size();
+}
+
+idx_t ReadParquetData::getTotalRows() {
+	if (totalRows_ == 0)
+		getMaxThread(); // populates totalRows_ from metadata
+	return totalRows_;
 }
 
 
@@ -171,6 +179,13 @@ static idx_t readParquetMaxThread(ClientContext &context, const FunctionData *bi
 	return bind_data.getMaxThread();
 }
 
+static idx_t readParquetCardinality(ClientContext &context, const FunctionData *bind_data_p) {
+	auto &bind_data = (ReadParquetData &)*bind_data_p;
+	// Exact row count from parquet metadata: a precise upper bound on the number
+	// of groups for a downstream aggregation, so its hash table is sized once.
+	return bind_data.getTotalRows();
+}
+
 static void readParquetFunction(ClientContext &context, const FunctionData *bind_data_p,
 									 FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &bind_data = (ReadParquetData &)*bind_data_p;
@@ -228,6 +243,7 @@ string ReadParquetFunc::getName() {
 function_ptr_t ReadParquetFunc::createFunction(const vector<LogicalType> &type) {
 	string name = getName();
 	function_ptr_t fun = function_ptr_t(new PredFunction( name, {PhysicalType::STRING}, readParquetFunction, readParquetBind, readParquetInit, readParquetMaxThread, nullptr, nullptr));
+	((PredFunction&)*fun).cardinalityFunction_ = readParquetCardinality;
 	readParquetAddNamedParameters((PredFunction&)*fun);
 	return fun;
 }

--- a/src/function/predicate/ReadParquet.cpp
+++ b/src/function/predicate/ReadParquet.cpp
@@ -26,7 +26,6 @@ idx_t ReadParquetData::getMaxThread() {
 	ParquetOptions options;
 
 	filesToProcess_.clear();
-	totalRows_ = 0;
 	for (idx_t fileIdx = 0; fileIdx < files_.size(); ++fileIdx) {
 		ParquetReader reader(context_, files_[fileIdx], options);
 		auto metadata = reader.getFileMetadata();
@@ -36,7 +35,6 @@ idx_t ReadParquetData::getMaxThread() {
 
 		for (idx_t rgIdx = 0; rgIdx < metadata->row_groups.size(); ++rgIdx) {
 			const auto rows = metadata->row_groups[rgIdx].num_rows;
-			totalRows_ += rows;
 
 			// If adding this group would exceed the morsel and we already have something, flush.
 			if (currentRows > 0 && currentRows + rows > MORSEL_SIZE) {
@@ -56,12 +54,6 @@ idx_t ReadParquetData::getMaxThread() {
 	}
 
 	return filesToProcess_.size();
-}
-
-idx_t ReadParquetData::getTotalRows() {
-	if (totalRows_ == 0)
-		getMaxThread(); // populates totalRows_ from metadata
-	return totalRows_;
 }
 
 
@@ -179,13 +171,6 @@ static idx_t readParquetMaxThread(ClientContext &context, const FunctionData *bi
 	return bind_data.getMaxThread();
 }
 
-static idx_t readParquetCardinality(ClientContext &context, const FunctionData *bind_data_p) {
-	auto &bind_data = (ReadParquetData &)*bind_data_p;
-	// Exact row count from parquet metadata: a precise upper bound on the number
-	// of groups for a downstream aggregation, so its hash table is sized once.
-	return bind_data.getTotalRows();
-}
-
 static void readParquetFunction(ClientContext &context, const FunctionData *bind_data_p,
 									 FunctionOperatorData *operator_state, DataChunk *input, DataChunk &output) {
 	auto &bind_data = (ReadParquetData &)*bind_data_p;
@@ -243,7 +228,6 @@ string ReadParquetFunc::getName() {
 function_ptr_t ReadParquetFunc::createFunction(const vector<LogicalType> &type) {
 	string name = getName();
 	function_ptr_t fun = function_ptr_t(new PredFunction( name, {PhysicalType::STRING}, readParquetFunction, readParquetBind, readParquetInit, readParquetMaxThread, nullptr, nullptr));
-	((PredFunction&)*fun).cardinalityFunction_ = readParquetCardinality;
 	readParquetAddNamedParameters((PredFunction&)*fun);
 	return fun;
 }

--- a/src/function/predicate/ReadParquet.cpp
+++ b/src/function/predicate/ReadParquet.cpp
@@ -137,14 +137,38 @@ static function_data_ptr_t readParquetBind(ClientContext &context,
 		returnTypes.push_back(result->reader_->returnTypes_[col]);
 	}
 
+	// Build the scan layout: the distinct file columns in first-use order. The
+	// scan chunk holds only these, and outputMap_ projects them to the output
+	// positions (handling a column requested more than once without reading the
+	// same file column twice, which would double-advance its reader).
+	result->scanCols_.clear();
+	result->outputMap_.clear();
+	result->scanTypes_.clear();
+	for (auto col : result->cols_) {
+		idx_t pos = result->scanCols_.size();
+		for (idx_t i = 0; i < result->scanCols_.size(); ++i)
+			if (result->scanCols_[i] == col) { pos = i; break; }
+		if (pos == result->scanCols_.size()) {
+			result->scanCols_.push_back(col);
+			result->scanTypes_.push_back(result->reader_->returnTypes_[col]);
+		}
+		result->outputMap_.push_back(pos);
+	}
+
 	if (!filters.filters_.empty()) {
 		result->filters_ = table_filter_set_ptr_t(new TableFilterSet());
-		// index of the table filter is based on the column name passed in name, we need to find the real index
+		// the table filter index refers to the output name position; remap it to
+		// the column's position in the scan chunk (scanCols_)
 		for (auto& [idx, filter]:filters.filters_) {
 			BB_ASSERT(idx < names.size());
 			auto realName = columnMapping[names[idx]];
 			auto realIdx = result->reader_->colNormalizedIdx_[realName];
-			result->filters_->pushFilter(realIdx, std::move(filter));
+			for (idx_t p = 0; p < result->scanCols_.size(); ++p) {
+				if (result->scanCols_[p] == realIdx) {
+					result->filters_->pushFilter(p, std::move(filter));
+					break;
+				}
+			}
 		}
 	}
 
@@ -186,31 +210,25 @@ static void readParquetFunction(ClientContext &context, const FunctionData *bind
 		for (idx_t i=data.filesToProcess_.groupStart_;i<=data.filesToProcess_.groupEnd_;++i)
 			groups.push_back(i);
 
-		// set the non-needed columns to COLUMN_IDENTIFIER_ROW_ID
-		vector<idx_t> colIdx;
-		std::unordered_set colsSet(bind_data.cols_.begin(), bind_data.cols_.end());
-		for (idx_t i=0;i<reader->names_.size();++i) {
-			if (colsSet.contains(i))
-				colIdx.emplace_back(i);
-			else
-				colIdx.push_back(COLUMN_IDENTIFIER_ROW_ID);
-		}
-		reader->initializeScan(data.readerState_, colIdx, groups, bind_data.filters_.get());
-		data.readChunk_.initialize(reader->returnTypes_);
+		// scan only the selected file columns: the scan chunk has one vector per
+		// scanCols_ entry, so per-chunk setup/slice/reset don't touch the file
+		// columns the query never reads
+		reader->initializeScan(data.readerState_, bind_data.scanCols_, groups, bind_data.filters_.get());
+		data.readChunk_.initialize(bind_data.scanTypes_);
 		data.initialized_ = true;
 	}
 
 	reader->scan(data.readerState_, data.readChunk_);
 
-	output.reference(data.readChunk_, bind_data.cols_);
+	output.reference(data.readChunk_, bind_data.outputMap_);
 
 	if (output.getSize() == 0 ) {
 		// exhausted
 		data.finished_ = true;
 		data.readChunk_.data_.clear();
 	}else {
-		// data.readChunk_.reset();
-		data.readChunk_.reset(bind_data.cols_);
+		// every column of the (narrow) scan chunk is selected, reset them all
+		data.readChunk_.reset();
 	}
 
 }

--- a/src/function/predicate/StringLike.cpp
+++ b/src/function/predicate/StringLike.cpp
@@ -19,130 +19,26 @@
 #include "bumblebee/function/predicate/StringLike.hpp"
 
 #include "bumblebee/common/vector_operations/UnaryExecution.hpp"
+#include <cstring>
 
 
 namespace bumblebee{
 
 
-template <class UNSIGNED, int NEEDLE_SIZE>
-static idx_t containsUnaligned(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
-                               idx_t base_offset) {
-	if (NEEDLE_SIZE > haystack_size) {
-		// needle is bigger than haystack: haystack cannot contain needle
-		return -1;
-	}
-	// contains for a small unaligned needle (3/5/6/7 bytes)
-	// we perform unsigned integer comparisons to check for equality of the entire needle in a single comparison
-
-	UNSIGNED needle_entry = 0;
-	UNSIGNED haystack_entry = 0;
-	const UNSIGNED start = (sizeof(UNSIGNED) * 8) - 8;
-	const UNSIGNED shift = (sizeof(UNSIGNED) - NEEDLE_SIZE) * 8;
-	for (int i = 0; i < NEEDLE_SIZE; i++) {
-		needle_entry |= UNSIGNED(needle[i]) << UNSIGNED(start - i * 8);
-		haystack_entry |= UNSIGNED(haystack[i]) << UNSIGNED(start - i * 8);
-	}
-	// now we perform the actual search
-	for (idx_t offset = NEEDLE_SIZE; offset < haystack_size; offset++) {
-		// for this position we first compare the haystack with the needle
-		if (haystack_entry == needle_entry) {
-			return base_offset + offset - NEEDLE_SIZE;
-		}
-		// now we adjust the haystack entry by
-		// (1) removing the left-most character (shift by 8)
-		// (2) adding the next character (bitwise or, with potential shift)
-		// this shift is only necessary if the needle size is not aligned with the unsigned integer size
-		// (e.g. needle size 3, unsigned integer size 4, we need to shift by 1)
-		haystack_entry = (haystack_entry << 8) | ((UNSIGNED(haystack[offset])) << shift);
-	}
-	if (haystack_entry == needle_entry) {
-		return base_offset + haystack_size - NEEDLE_SIZE;
-	}
-	return -1;
-}
-
-template <class UNSIGNED>
-static idx_t containsAligned(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
-                             idx_t base_offset) {
-	if (sizeof(UNSIGNED) > haystack_size) {
-		// needle is bigger than haystack: haystack cannot contain needle
-		return -1;
-	}
-	// contains for a small needle aligned with unsigned integer (2/4/8)
-	// similar to ContainsUnaligned, but simpler because we only need to do a reinterpret cast
-	auto needle_entry = load<UNSIGNED>(needle);
-	for (idx_t offset = 0; offset <= haystack_size - sizeof(UNSIGNED); offset++) {
-		// for this position we first compare the haystack with the needle
-		auto haystack_entry = load<UNSIGNED>(haystack + offset);
-		if (needle_entry == haystack_entry) {
-			return base_offset + offset;
-		}
-	}
-	return -1;
-}
-
-idx_t containsGeneric(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
-                      idx_t needle_size, idx_t base_offset) {
-	if (needle_size > haystack_size) {
-		// needle is bigger than haystack: haystack cannot contain needle
-		return -1;
-	}
-	// we keep track of a shifting window sum of all characters with window size equal to needle_size
-	// this shifting sum is used to avoid calling into memcmp;
-	// we only need to call into memcmp when the window sum is equal to the needle sum
-	// when that happens, the characters are potentially the same and we call into memcmp to check if they are
-	uint32_t sums_diff = 0;
-	for (idx_t i = 0; i < needle_size; i++) {
-		sums_diff += haystack[i];
-		sums_diff -= needle[i];
-	}
-	idx_t offset = 0;
-	while (true) {
-		if (sums_diff == 0 && haystack[offset] == needle[0]) {
-			if (memcmp(haystack + offset, needle, needle_size) == 0) {
-				return base_offset + offset;
-			}
-		}
-		if (offset >= haystack_size - needle_size) {
-			return -1;
-		}
-		sums_diff -= haystack[offset];
-		sums_diff += haystack[offset + needle_size];
-		offset++;
-	}
-}
-
+// Find the first occurrence of `needle` within `haystack`, or -1 if absent.
+// Delegates to memmem, whose Two-Way/SIMD implementation is faster than a
+// per-position windowed scan for the long haystacks (URLs) typical of LIKE
+// '%substr%' predicates, which dominate such queries.
 int find(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle, idx_t needle_size) {
 	BB_ASSERT(needle_size > 0);
-	// start off by performing a memchr to find the first character
-	auto location = memchr(haystack, needle[0], haystack_size);
+	if (needle_size > haystack_size) {
+		return -1;
+	}
+	auto location = memmem(haystack, haystack_size, needle, needle_size);
 	if (location == nullptr) {
 		return -1;
 	}
-	idx_t base_offset = (const unsigned char *)location - haystack;
-	haystack_size -= base_offset;
-	haystack = (const unsigned char *)location;
-	// switch algorithm depending on needle size
-	switch (needle_size) {
-		case 1:
-			return base_offset;
-		case 2:
-			return containsAligned<uint16_t>(haystack, haystack_size, needle, base_offset);
-		case 3:
-			return containsUnaligned<uint32_t, 3>(haystack, haystack_size, needle, base_offset);
-		case 4:
-			return containsAligned<uint32_t>(haystack, haystack_size, needle, base_offset);
-		case 5:
-			return containsUnaligned<uint64_t, 5>(haystack, haystack_size, needle, base_offset);
-		case 6:
-			return containsUnaligned<uint64_t, 6>(haystack, haystack_size, needle, base_offset);
-		case 7:
-			return containsUnaligned<uint64_t, 7>(haystack, haystack_size, needle, base_offset);
-		case 8:
-			return containsAligned<uint64_t>(haystack, haystack_size, needle, base_offset);
-		default:
-			return containsGeneric(haystack, haystack_size, needle, needle_size, base_offset);
-	}
+	return (int)((const unsigned char *)location - haystack);
 }
 
 

--- a/src/include/bumblebee/common/BufferedCSVReader.hpp
+++ b/src/include/bumblebee/common/BufferedCSVReader.hpp
@@ -70,8 +70,14 @@ struct BufferedCSVReaderOptions {
 	idx_t numCols_ = 0;
 	// Size of sample chunk used for dialect and type detection
 	idx_t sampleChunkSize_ = STANDARD_VECTOR_SIZE;
-	// Number of sample chunks used for type detection
-	idx_t sampleChunks_ = 75;
+	// Number of sample chunks used for type detection. Sniffing is single
+	// threaded and parses + type-casts every sampled row of every column, so it
+	// runs before any parallel scanning can start; 20 chunks (20480 rows, on par
+	// with DuckDB's default sample size) keeps detection robust — samples are
+	// spread across the whole file for large files — without the sniff dominating
+	// query time on wide files. Tunable per query via the sample_size /
+	// sample_chunks named parameters of &read_csv.
+	idx_t sampleChunks_ = 20;
 	// Number of samples to buffer
 	idx_t bufferSize_ = STANDARD_VECTOR_SIZE * 100;
 	// Consider all columns to be of type varchar

--- a/src/include/bumblebee/common/Hash.hpp
+++ b/src/include/bumblebee/common/Hash.hpp
@@ -46,9 +46,15 @@ template <>
 hash_t Hash(char *val);
 template <>
 hash_t Hash(string val);
-template <>
-hash_t Hash(string_t val);
 hash_t Hash(const char *val, size_t size);
+
+// Inline so the per-row hashing loops in group-by/join don't pay an
+// out-of-line call (plus a by-value string_t copy) per value; the actual
+// byte-mixing loop stays in Hash(const char*, size_t).
+template <>
+inline hash_t Hash(string_t val) {
+	return Hash(val.getDataUnsafe(), val.size());
+}
 
 
 struct StringTHash {

--- a/src/include/bumblebee/common/StringUtils.hpp
+++ b/src/include/bumblebee/common/StringUtils.hpp
@@ -39,8 +39,10 @@ public:
     static bool glob(const string& str,const string& pattern);
     static bool hasGlob(const string &str);
     static bool characterIsSpace(char c);
-    static bool characterIsDigit(char c);
-    static bool characterIsNewline(char c);
+    // Hot in CSV parsing (called per character): defined inline so call sites in
+    // other translation units don't pay a non-inlined function call per byte.
+    static inline bool characterIsDigit(char c) { return c >= '0' && c <= '9'; }
+    static inline bool characterIsNewline(char c) { return c == '\n' || c == '\r'; }
     static string upper(const string &str);
     static string lower(const string &str);
     static void removeQuote(string& str);

--- a/src/include/bumblebee/common/operator/ComparisonOperators.hpp
+++ b/src/include/bumblebee/common/operator/ComparisonOperators.hpp
@@ -26,39 +26,39 @@ namespace bumblebee{
 //===--------------------------------------------------------------------===//
 struct Equals {
 	template <class T>
-	static inline bool operation(T left, T right) {
+	static inline bool operation(const T& left, const T& right) {
 		return left == right;
 	}
 };
 
 struct NotEquals {
 	template <class T>
-	static inline bool operation(T left, T right) {
+	static inline bool operation(const T& left, const T& right) {
 		return left != right;
 	}
 };
 struct GreaterThan {
 	template <class T>
-	static inline bool operation(T left, T right) {
+	static inline bool operation(const T& left, const T& right) {
 		return left > right;
 	}
 };
 struct GreaterThanEquals {
 	template <class T>
-	static inline bool operation(T left, T right) {
+	static inline bool operation(const T& left, const T& right) {
 		return left >= right;
 	}
 };
 
 struct LessThan {
 	template <class T>
-	static inline bool operation(T left, T right) {
+	static inline bool operation(const T& left, const T& right) {
 		return left < right;
 	}
 };
 struct LessThanEquals {
 	template <class T>
-	static inline bool operation(T left, T right) {
+	static inline bool operation(const T& left, const T& right) {
 		return left <= right;
 	}
 };
@@ -67,11 +67,11 @@ struct LessThanEquals {
 // Specialized Boolean Comparison Operators
 //===--------------------------------------------------------------------===//
 template <>
-inline bool GreaterThan::operation(bool left, bool right) {
+inline bool GreaterThan::operation(const bool& left, const bool& right) {
 	return !right && left;
 }
 template <>
-inline bool LessThan::operation(bool left, bool right) {
+inline bool LessThan::operation(const bool& left, const bool& right) {
 	return !left && right;
 }
 //===--------------------------------------------------------------------===//
@@ -79,42 +79,30 @@ inline bool LessThan::operation(bool left, bool right) {
 //===--------------------------------------------------------------------===//
 struct StringComparisonOperators {
 	template <bool INVERSE>
-	static inline bool EqualsOrNot(const string_t a, const string_t b) {
-		auto size = a.size();
-		if (size != b.length()) return INVERSE ? true : false;
-		if (a.isInlined()) {
-			// small string: compare entire string
-			if (memcmp(a.getPrefix(), b.getPrefix(), size) == 0) {
-				// entire string is equal
-				return INVERSE ? false : true;
-			}
-		} else {
-			// large string: first check prefix and length
-			if (memcmp(a.getPrefix(), b.getPrefix(), string_t::PREFIX_LENGTH) == 0) {
-				// prefix and length are equal: check main string
-				if (memcmp(a.c_str(), b.c_str(), size) == 0) {
-					// entire string is equal
-					return INVERSE ? false : true;
-				}
-			}
-		}
-		// not equal
-		return INVERSE ? true : false;
+	static inline bool EqualsOrNot(const string_t& a, const string_t& b) {
+		// Compare via getDataUnsafe() (inlined prefix or external ptr) rather than the
+		// raw prefix field. The prefix is only guaranteed consistent for strings built
+		// through the (data,len) constructor; comparing the actual data keeps this
+		// correct for every string_t source (matching BumbleString::operator==).
+		const auto size = a.size();
+		if (size != b.size()) return INVERSE ? true : false;
+		const bool equal = memcmp(a.getDataUnsafe(), b.getDataUnsafe(), size) == 0;
+		return INVERSE ? !equal : equal;
 	}
 };
 
 template <>
-inline bool Equals::operation(string_t left, string_t right) {
+inline bool Equals::operation(const string_t& left, const string_t& right) {
 	return StringComparisonOperators::EqualsOrNot<false>(left, right);
 }
 template <>
-inline bool NotEquals::operation(string_t left, string_t right) {
+inline bool NotEquals::operation(const string_t& left, const string_t& right) {
 	return StringComparisonOperators::EqualsOrNot<true>(left, right);
 }
 
 // compare up to shared length. if still the same, compare lengths
 template <class OP>
-static bool templated_string_compare_op(string_t left, string_t right) {
+static bool templated_string_compare_op(const string_t& left, const string_t& right) {
 	auto memcmp_res =
 	    memcmp(left.getDataUnsafe(), right.getDataUnsafe(), std::min(left.size(), right.size()));
 	auto final_res = memcmp_res == 0 ? OP::operation(left.size(), right.size()) : OP::operation(memcmp_res, 0);
@@ -122,22 +110,22 @@ static bool templated_string_compare_op(string_t left, string_t right) {
 }
 
 template <>
-inline bool GreaterThan::operation(string_t left, string_t right) {
+inline bool GreaterThan::operation(const string_t& left, const string_t& right) {
 	return templated_string_compare_op<GreaterThan>(left, right);
 }
 
 template <>
-inline bool GreaterThanEquals::operation(string_t left, string_t right) {
+inline bool GreaterThanEquals::operation(const string_t& left, const string_t& right) {
 	return templated_string_compare_op<GreaterThanEquals>(left, right);
 }
 
 template <>
-inline bool LessThan::operation(string_t left, string_t right) {
+inline bool LessThan::operation(const string_t& left, const string_t& right) {
 	return templated_string_compare_op<LessThan>(left, right);
 }
 
 template <>
-inline bool LessThanEquals::operation(string_t left, string_t right) {
+inline bool LessThanEquals::operation(const string_t& left, const string_t& right) {
 	return templated_string_compare_op<LessThanEquals>(left, right);
 }
 

--- a/src/include/bumblebee/common/parquet/ColumnReader.hpp
+++ b/src/include/bumblebee/common/parquet/ColumnReader.hpp
@@ -147,8 +147,18 @@ protected:
 
 private:
 	void prepareRead(parquet_filter_t &filter);
-	void preparePage(idx_t compressed_page_size, idx_t uncompressed_page_size);
+	void preparePage(idx_t compressed_page_size, idx_t uncompressed_page_size, bool poolable);
 	void prepareDataPage(PageHeader &page_hdr);
+
+	// Acquire a decompressed-page buffer from the reader-local pool, reusing one
+	// no longer referenced by any live output chunk (use_count == 1) instead of
+	// allocating a fresh one. Data pages are referenced zero-copy by string
+	// columns, so a single block_ slot cannot be reused while a chunk still holds
+	// the previous page; without a pool every page hits malloc/free of a buffer
+	// above glibc's mmap threshold, so each page faults in fresh zero pages and
+	// the per-mm kernel lock on mmap/munmap serializes scan threads. Recycling a
+	// small set of buffers keeps their pages resident and avoids that churn.
+	std::shared_ptr<ResizeableBuffer> acquireDecompressed(idx_t size);
 
 	const bumblebee::format::ColumnChunk *chunk_;
 
@@ -160,6 +170,12 @@ private:
 	std::shared_ptr<ResizeableBuffer> block_;
 	// reused per-page compressed read buffer (transient decompressor input)
 	ResizeableBuffer compressedBuffer_;
+
+	// Pool of decompressed data-page buffers recycled across pages (see
+	// acquireDecompressed). Dictionary-page buffers are not pooled (one per row
+	// group, moved into dict_), so this only holds the small working set of
+	// per-page buffers in flight for this column.
+	std::vector<std::shared_ptr<ResizeableBuffer>> decompressedPool_;
 
 	ResizeableBuffer offsetBuffer_;
 

--- a/src/include/bumblebee/common/parquet/ColumnReader.hpp
+++ b/src/include/bumblebee/common/parquet/ColumnReader.hpp
@@ -158,6 +158,8 @@ private:
 	idx_t chunkReadOffset_;
 
 	std::shared_ptr<ResizeableBuffer> block_;
+	// reused per-page compressed read buffer (transient decompressor input)
+	ResizeableBuffer compressedBuffer_;
 
 	ResizeableBuffer offsetBuffer_;
 

--- a/src/include/bumblebee/common/parquet/ColumnReader.hpp
+++ b/src/include/bumblebee/common/parquet/ColumnReader.hpp
@@ -121,6 +121,16 @@ protected:
 		return maxDefine_ > 0;
 	}
 
+	// True when no value in defines[offset, offset+count) is NULL (i.e. every
+	// definition level equals the column maximum). Lets decode loops take a
+	// branch-free batch path for the common all-valid case.
+	bool allDefined(const uint8_t *defines, idx_t offset, idx_t count) {
+		if (!hasDefines()) return true;
+		for (idx_t i = 0; i < count; i++)
+			if (defines[i + offset] != maxDefine_) return false;
+		return true;
+	}
+
 	bool hasRepeats() {
 		return maxRepeat_ > 0;
 	}

--- a/src/include/bumblebee/common/parquet/ParquetReader.hpp
+++ b/src/include/bumblebee/common/parquet/ParquetReader.hpp
@@ -98,6 +98,10 @@ public:
 	string getAvailableColumns() const;
 
 	idx_t numRows();
+	// Normalized column name -> file column index, or (idx_t)-1 if absent.
+	idx_t columnIndex(const string &normalizedName) const { auto it = colNormalizedIdx_.find(normalizedName); return it != colNormalizedIdx_.end() ? it->second : (idx_t)-1; }
+	// Logical (not physical) type of a file column, carrying DATE/TIMESTAMP/etc.
+	LogicalType columnLogicalType(idx_t i) const { return i < returnTypes_.size() ? returnTypes_[i] : LogicalType(); }
 	idx_t numRowGroups();
 
 	const bumblebee::format::FileMetaData *getFileMetadata();

--- a/src/include/bumblebee/common/parquet/ResizeableBuffer.hpp
+++ b/src/include/bumblebee/common/parquet/ResizeableBuffer.hpp
@@ -85,8 +85,13 @@ public:
         if (new_size > allocLen_) {
             allocLen_ = new_size;
             allocatedData_ = allocator.allocate(allocLen_);
-            ptr_ = (char *)allocatedData_->get();
         }
+        // Always reset ptr_ to the allocation base. A previous user of this buffer
+        // may have advanced ptr_ via ByteBuffer::inc()/read() while consuming a
+        // page; when the buffer is reused without reallocating, ptr_ must point
+        // back at the start or the next writer (e.g. page decompression) would
+        // run past the end of the allocation.
+        ptr_ = (char *)allocatedData_->get();
     }
 
 private:

--- a/src/include/bumblebee/common/parquet/RleBpDecoder.hpp
+++ b/src/include/bumblebee/common/parquet/RleBpDecoder.hpp
@@ -138,7 +138,24 @@ private:
 	uint32_t bitUnpack(T *dest, uint32_t count) {
 		auto mask = BITPACK_MASKS[bitWidth_];
 
-		for (uint32_t i = 0; i < count; i++) {
+		uint32_t i = 0;
+		// Fast path: while at least 8 bytes remain we can read a 64-bit little-endian
+		// window per value (a value spans at most bitpackPos_(<=7) + bitWidth_(<=32)
+		// = 39 bits, always inside the window) and advance by whole consumed bytes.
+		// This avoids the per-byte boundary loop. Bit order is LSB-first, matching
+		// the scalar path below.
+		while (i < count && buffer_.len_ >= 8) {
+			uint64_t window = load<uint64_t>((data_ptr_t)buffer_.ptr_);
+			dest[i++] = (T)((window >> bitpackPos_) & mask);
+			bitpackPos_ += bitWidth_;
+			idx_t consumed = bitpackPos_ >> 3;        // whole bytes now consumed
+			buffer_.ptr_ += consumed;
+			buffer_.len_ -= consumed;
+			bitpackPos_ &= 7;
+		}
+
+		// Tail: byte-by-byte for the final values where fewer than 8 bytes remain.
+		for (; i < count; i++) {
 			T val = (buffer_.get<uint8_t>() >> bitpackPos_) & mask;
 			bitpackPos_ += bitWidth_;
 			while (bitpackPos_ > BITPACK_DLEN) {

--- a/src/include/bumblebee/common/parquet/TemplatedColumnReader.hpp
+++ b/src/include/bumblebee/common/parquet/TemplatedColumnReader.hpp
@@ -21,6 +21,8 @@
 #include "ColumnReader.hpp"
 #include "bumblebee/common/Limits.hpp"
 
+#include <type_traits>
+
 namespace bumblebee{
 
 
@@ -63,6 +65,19 @@ public:
 		BB_ASSERT(result.getVectorType() == VectorType::FLAT_VECTOR);
 		auto result_ptr = FlatVector::getData<VALUE_TYPE>(result);
 
+		if constexpr (std::is_same_v<VALUE_CONVERSION, TemplatedParquetValueConversion<VALUE_TYPE>>) {
+			// Fast path for plain fixed-width dictionary values: when the batch has
+			// no NULLs and no row is filtered out, the per-row loop below
+			// degenerates to a branch-free dictionary gather. Only valid for the
+			// trivial conversion, whose dictRead is exactly dict[offset].
+			if (filter.all() && allDefined(defines, result_offset, num_values)) {
+				auto dict_ptr = (VALUE_TYPE *)dict_->ptr_;
+				for (idx_t i = 0; i < num_values; i++)
+					result_ptr[i + result_offset] = dict_ptr[offsets[i]];
+				return;
+			}
+		}
+
 		idx_t offset_idx = 0;
 		for (idx_t row_idx = 0; row_idx < num_values; row_idx++) {
 			if (hasDefines() && defines[row_idx + result_offset] != maxDefine_) {
@@ -86,6 +101,19 @@ public:
 	void plain(std::shared_ptr<ByteBuffer> plain_data, uint8_t *defines, uint64_t num_values, parquet_filter_t &filter,
 	           idx_t result_offset, Vector &result) override {
 		auto result_ptr = FlatVector::getData<VALUE_TYPE>(result);
+
+		if constexpr (std::is_same_v<VALUE_CONVERSION, TemplatedParquetValueConversion<VALUE_TYPE>>) {
+			// Fast path for plain fixed-width values: with no NULLs and no filtered
+			// rows, the per-row read<T> loop is a straight buffer copy. copy_to/inc
+			// perform the same bounds check the per-value reads would.
+			if (filter.all() && allDefined(defines, result_offset, num_values)) {
+				const uint64_t bytes = num_values * sizeof(VALUE_TYPE);
+				plain_data->copy_to((char *)(result_ptr + result_offset), bytes);
+				plain_data->inc(bytes);
+				return;
+			}
+		}
+
 		for (idx_t row_idx = 0; row_idx < num_values; row_idx++) {
 			if (hasDefines() && defines[row_idx + result_offset] != maxDefine_) {
 				// NULL: a definition level below the column max means the value is

--- a/src/include/bumblebee/common/types/BumbleString.hpp
+++ b/src/include/bumblebee/common/types/BumbleString.hpp
@@ -17,6 +17,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
+#include <cstring>
 #include <string>
 
 #include "bumblebee/common/TypeDefs.hpp"
@@ -45,11 +46,33 @@ public:
     // lenght set to 11 as total data should fit in 24 bytes (multiple of 8)
     static constexpr idx_t PREFIX_LENGTH = 11;
 
+    // These member functions are deliberately defined inline in the header:
+    // construction, hashing and comparison of strings run once per row in
+    // scans, group-bys and joins, and an out-of-line call per value dominated
+    // string-heavy query profiles.
     BumbleString() = default;
-    BumbleString(uint32_t len);
-    BumbleString(const char* data);
-    BumbleString(const char* data, uint32_t len);
-    BumbleString(const BumbleString& other);
+    inline BumbleString(uint32_t len) {
+        value_.length = len;
+    }
+    inline BumbleString(const char* data, uint32_t len) {
+        value_.length = len;
+        if (isInlined()) {
+            // store the data in prefix
+            // +1 for string termination
+            memcpy(value_.prefix, data, len * sizeof(char));
+            value_.prefix[len] = '\0';
+            return;
+        }
+        memcpy(value_.prefix, data, PREFIX_LENGTH * sizeof(char));
+        value_.prefix[PREFIX_LENGTH] = '\0';
+        value_.ptr = (char *)(data);
+    }
+    inline BumbleString(const char* data): BumbleString(data, strlen(data)) {}
+    // Member-wise copy: the prefix always mirrors the referenced data, so the
+    // default copy is equivalent to re-deriving it (and matches the implicitly
+    // defaulted copy assignment). Keeping the type trivially copyable lets it
+    // be passed in registers.
+    BumbleString(const BumbleString& other) = default;
 
 
     inline bool isInlined() const {
@@ -60,7 +83,11 @@ public:
             return value_.prefix;
         return value_.ptr;
     }
-    char * getDataWriteable() const ;
+    inline char *getDataWriteable() const {
+        if (isInlined())
+            return (char*)value_.prefix;
+        return value_.ptr;
+    }
     inline const char * getPrefix() const {
         return value_.prefix;
     }
@@ -73,13 +100,34 @@ public:
     }
     string getString() const;
 
-    bool operator<(const BumbleString &r) const;
-    bool operator>(const BumbleString &r) const;
-    bool operator==(const BumbleString &r) const;
-    const char* c_str() const;
+    inline bool operator<(const BumbleString &r) const {
+        // compare the data: length-aware memcmp. strcmp is unusable here because
+        // byte-comparable sort keys contain embedded NUL bytes.
+        auto left_length = size();
+        auto right_length = r.size();
+        auto min_length = left_length < right_length ? left_length : right_length;
+        auto memcmp_res = memcmp(getDataUnsafe(), r.getDataUnsafe(), min_length);
+        return memcmp_res < 0 || (memcmp_res == 0 && left_length < right_length);
+    }
+    inline bool operator>(const BumbleString &r) const {
+        auto left_length = size();
+        auto right_length = r.size();
+        auto min_length = left_length < right_length ? left_length : right_length;
+        auto memcmp_res = memcmp(getDataUnsafe(), r.getDataUnsafe(), min_length);
+        return memcmp_res > 0 || (memcmp_res == 0 && left_length > right_length);
+    }
+    inline bool operator==(const BumbleString &r) const {
+        auto left_length = size();
+        return left_length == r.size() && memcmp(getDataUnsafe(), r.getDataUnsafe(), left_length) == 0;
+    }
+    inline const char* c_str() const {
+        return getDataUnsafe();
+    }
 
     // return true if the string is inline
-    static bool isInlined( uint32_t len);
+    static inline bool isInlined(uint32_t len) {
+        return len <= PREFIX_LENGTH;
+    }
 private:
     struct {
         // +1 for end termination

--- a/src/include/bumblebee/execution/AggregatePRLHashTable.hpp
+++ b/src/include/bumblebee/execution/AggregatePRLHashTable.hpp
@@ -74,6 +74,10 @@ public:
     vector<LogicalType> getPayloadsTypes();
 
     void moveAndMergeStates(idx_t count, Vector &addresses, Vector &hashes);
+    // Tuple-level merge fast path for fixed-width group keys: copies whole source
+    // tuples for new groups and combines states for matches, avoiding the generic
+    // gather/scatter/init round trip.
+    void moveAndMergeStatesFixed(idx_t count, Vector &addresses, Vector &hashes);
 
 private:
     void findAddresses(Vector &hash, DataChunk &groups, SelectionVector &sel, Vector &addresses, idx_t &matchedGroups);

--- a/src/include/bumblebee/execution/AggregatePRLHashTable.hpp
+++ b/src/include/bumblebee/execution/AggregatePRLHashTable.hpp
@@ -84,6 +84,12 @@ private:
     // Helper for scanWithAggregates: builds addresses and gathers group values
     idx_t scanEntries(idx_t offset, DataChunk &groups, Vector &addresses, idx_t size);
 
+    // Copy a string payload's (non-inlined) values into this table's stringHeap_
+    // and repoint the vector at the copies, so string aggregate states (MIN/MAX)
+    // that keep a shallow string_t reference point at heap memory owned and
+    // merged by this table rather than at the transient scan/decode buffer.
+    void internalizeStrings(Vector &payload, idx_t count);
+
     // Aggregates functions
     vector<AggregateFunction*> functions_;
 };

--- a/src/include/bumblebee/execution/PRLHashTable.hpp
+++ b/src/include/bumblebee/execution/PRLHashTable.hpp
@@ -85,7 +85,7 @@ public:
     using distinct_ht_ptr_t = std::unique_ptr<PRLHashTable>;
 
     // The hash table load factor, when a resize is triggered
-    constexpr static float LOAD_FACTOR = 0.5;
+    constexpr static float LOAD_FACTOR = 0.6;
 
 
     PRLHashTable(BufferManager& manager, const vector<LogicalType>& types, idx_t capacity = HT_INIT_CAPACITY, bool resizable = true);

--- a/src/include/bumblebee/execution/PRLHashTable.hpp
+++ b/src/include/bumblebee/execution/PRLHashTable.hpp
@@ -85,7 +85,7 @@ public:
     using distinct_ht_ptr_t = std::unique_ptr<PRLHashTable>;
 
     // The hash table load factor, when a resize is triggered
-    constexpr static float LOAD_FACTOR = 0.6;
+    constexpr static float LOAD_FACTOR = 0.75;
 
 
     PRLHashTable(BufferManager& manager, const vector<LogicalType>& types, idx_t capacity = HT_INIT_CAPACITY, bool resizable = true);

--- a/src/include/bumblebee/execution/PartitionedAggHT.hpp
+++ b/src/include/bumblebee/execution/PartitionedAggHT.hpp
@@ -169,6 +169,9 @@ private:
     vector<LogicalType> types_;
     // If we need to calculate distinct of values
     bool distinct_{false};
+    // True iff some aggregate keeps variable-length (string-heap-referencing) state,
+    // requiring the local HT's string heap to be carried over when combining.
+    bool aggStateVarlen_{false};
 };
 
 using partitioned_agg_ht_ptr_t = std::unique_ptr<PartitionedAggHT>;

--- a/src/include/bumblebee/execution/PhysicalAtom.hpp
+++ b/src/include/bumblebee/execution/PhysicalAtom.hpp
@@ -105,6 +105,11 @@ public:
 	virtual idx_t getMaxThreads() const;
 	virtual void setMaxThreads(idx_t threads) const;
 
+	// Estimated number of output rows (upper bound acceptable). Used to pre-size
+	// downstream structures (e.g. aggregation hash tables). The base value is a
+	// coarse estimate from the parallelism granularity.
+	virtual idx_t getEstimatedCardinality() const;
+
 	virtual bool isSource() const;
 	virtual bool isSink() const;
 	virtual string getName() const;

--- a/src/include/bumblebee/execution/PhysicalAtom.hpp
+++ b/src/include/bumblebee/execution/PhysicalAtom.hpp
@@ -105,11 +105,6 @@ public:
 	virtual idx_t getMaxThreads() const;
 	virtual void setMaxThreads(idx_t threads) const;
 
-	// Estimated number of output rows (upper bound acceptable). Used to pre-size
-	// downstream structures (e.g. aggregation hash tables). The base value is a
-	// coarse estimate from the parallelism granularity.
-	virtual idx_t getEstimatedCardinality() const;
-
 	virtual bool isSource() const;
 	virtual bool isSink() const;
 	virtual string getName() const;

--- a/src/include/bumblebee/execution/TopNHeap.hpp
+++ b/src/include/bumblebee/execution/TopNHeap.hpp
@@ -31,6 +31,10 @@ struct ColModifier {
 struct TopNEntry {
     string_t sortKey_;
     idx_t index_;
+    // Monotonic order-code of the first sort column (see TopNHeap::orderCodeAt),
+    // cached so the sink can cheaply skip chunks that cannot beat the threshold.
+    uint64_t firstCode_{0};
+    bool firstValid_{false};
 
     string toString() const {
         string result = "STRING: ";
@@ -92,6 +96,16 @@ private:
         return maxValue<idx_t>(MORSEL_SIZE, 2ULL * heapSize_);
     }
 
+    // Monotonic encoding of the first sort column at row i of a flat vector:
+    // a smaller code sorts earlier (i.e. is "better") under the column's order.
+    // Only valid when prefilterEnabled_.
+    uint64_t orderCodeAt(Vector &v, idx_t i) const;
+
+    // True if at least one row in the chunk could enter a full heap (or if the
+    // chunk cannot be cheaply ruled out). When false, no row can beat the
+    // current threshold and the whole chunk can be skipped.
+    bool chunkCanContribute(DataChunk &input) const;
+
     // return true if we should add the entry
     inline bool shouldAddToHeap(const string_t &sortKey) {
         if (heap_.size() < heapSize_) {
@@ -121,6 +135,11 @@ private:
     vector<idx_t> sortCols_;
     vector<LogicalType> sortColTypes_;
     idx_t heapSize_;
+
+    // First-sort-column prefilter configuration (set in the constructor).
+    bool prefilterEnabled_{false};   // first sort col is a supported integer type
+    bool desc0_{false};              // first sort col is DESC
+    PhysicalType firstColPhysType_{PhysicalType::UNKNOWN};
 
     DataChunk heapData_;
     DataChunk heapPayload_;

--- a/src/include/bumblebee/execution/TopNHeap.hpp
+++ b/src/include/bumblebee/execution/TopNHeap.hpp
@@ -101,10 +101,9 @@ private:
     // Only valid when prefilterEnabled_.
     uint64_t orderCodeAt(Vector &v, idx_t i) const;
 
-    // True if at least one row in the chunk could enter a full heap (or if the
-    // chunk cannot be cheaply ruled out). When false, no row can beat the
-    // current threshold and the whole chunk can be skipped.
-    bool chunkCanContribute(DataChunk &input) const;
+    // Build sort keys for every row of the chunk and push qualifying rows into
+    // the heap. Assumes the chunk is already flat (normalified).
+    void sinkChunk(DataChunk &chunk);
 
     // return true if we should add the entry
     inline bool shouldAddToHeap(const string_t &sortKey) {
@@ -147,6 +146,7 @@ private:
     // Cached objects
     DataChunk keyStrings_;
     SelectionVector dataToInsert_;
+    SelectionVector candSel_;   // candidate rows surviving the first-column prefilter
 
     bool finalized_{false};
 

--- a/src/include/bumblebee/execution/atom/external/PhysicalPredFunction.hpp
+++ b/src/include/bumblebee/execution/atom/external/PhysicalPredFunction.hpp
@@ -34,7 +34,6 @@ public:
     ~PhysicalPredFunction() override;
 
     idx_t getMaxThreads() const override;
-    idx_t getEstimatedCardinality() const override;
     bool isSource() const override;
     bool isSink() const override;
 

--- a/src/include/bumblebee/execution/atom/external/PhysicalPredFunction.hpp
+++ b/src/include/bumblebee/execution/atom/external/PhysicalPredFunction.hpp
@@ -34,6 +34,7 @@ public:
     ~PhysicalPredFunction() override;
 
     idx_t getMaxThreads() const override;
+    idx_t getEstimatedCardinality() const override;
     bool isSource() const override;
     bool isSink() const override;
 

--- a/src/include/bumblebee/function/PredFunction.hpp
+++ b/src/include/bumblebee/function/PredFunction.hpp
@@ -72,11 +72,6 @@ public:
     pred_function_finalize_t finalize_function_;
     pred_function_combine_t combine_function_;
 
-    // Optional: estimate the number of rows the scan will produce (an upper
-    // bound is fine). Used to pre-size downstream hash tables. If null, callers
-    // fall back to a coarse estimate. Same signature as maxThreadFunction_.
-    pred_function_max_threads_t cardinalityFunction_ = nullptr;
-
     // The named parameters of the function
     std::unordered_map<string, PhysicalType> namedParameters_;
 };

--- a/src/include/bumblebee/function/PredFunction.hpp
+++ b/src/include/bumblebee/function/PredFunction.hpp
@@ -72,6 +72,11 @@ public:
     pred_function_finalize_t finalize_function_;
     pred_function_combine_t combine_function_;
 
+    // Optional: estimate the number of rows the scan will produce (an upper
+    // bound is fine). Used to pre-size downstream hash tables. If null, callers
+    // fall back to a coarse estimate. Same signature as maxThreadFunction_.
+    pred_function_max_threads_t cardinalityFunction_ = nullptr;
+
     // The named parameters of the function
     std::unordered_map<string, PhysicalType> namedParameters_;
 };

--- a/src/include/bumblebee/function/predicate/ReadParquet.hpp
+++ b/src/include/bumblebee/function/predicate/ReadParquet.hpp
@@ -66,10 +66,15 @@ struct ReadParquetData : public FunctionData {
     atomic<idx_t> nextFileToProcess_{0};
     vector<ReadParquetDataChunk> filesToProcess_;
 
+    // Total rows across all files, summed from parquet metadata by getMaxThread.
+    idx_t totalRows_{0};
+
     string extension_ = ".parquet";
 
     //Return the max thread to read the csv
     idx_t getMaxThread();
+    // Total row count across all files (from metadata); computes it if needed.
+    idx_t getTotalRows();
     // return the chunk to read for a thread
     ReadParquetDataChunk getNextChunksToRead();
 };

--- a/src/include/bumblebee/function/predicate/ReadParquet.hpp
+++ b/src/include/bumblebee/function/predicate/ReadParquet.hpp
@@ -59,7 +59,17 @@ struct ReadParquetData : public FunctionData {
 
     // The columns to select
     vector<idx_t> cols_;
+    // The file columns actually scanned: cols_ deduplicated, preserving order.
+    // The scan chunk contains exactly these columns, so wide files don't pay
+    // per-chunk vector setup/slice/reset for the 100+ columns a query ignores.
+    vector<idx_t> scanCols_;
+    // For each output column, its position inside scanCols_.
+    vector<idx_t> outputMap_;
+    // Logical types of scanCols_ (the scan chunk layout).
+    vector<LogicalType> scanTypes_;
 
+    // Filters are keyed by position in scanCols_ (the scan chunk / columnIds_
+    // position), which is what ParquetReader::prepareRowGroupBuffer expects.
     table_filter_set_ptr_t filters_;
 
     // file to be processed

--- a/src/include/bumblebee/function/predicate/ReadParquet.hpp
+++ b/src/include/bumblebee/function/predicate/ReadParquet.hpp
@@ -66,15 +66,10 @@ struct ReadParquetData : public FunctionData {
     atomic<idx_t> nextFileToProcess_{0};
     vector<ReadParquetDataChunk> filesToProcess_;
 
-    // Total rows across all files, summed from parquet metadata by getMaxThread.
-    idx_t totalRows_{0};
-
     string extension_ = ".parquet";
 
     //Return the max thread to read the csv
     idx_t getMaxThread();
-    // Total row count across all files (from metadata); computes it if needed.
-    idx_t getTotalRows();
     // return the chunk to read for a thread
     ReadParquetDataChunk getNextChunksToRead();
 };

--- a/src/include/bumblebee/parser/statement/Term.hpp
+++ b/src/include/bumblebee/parser/statement/Term.hpp
@@ -76,6 +76,7 @@ public:
 
 	Term(const Term &other)
 		: negative_(other.negative_),
+		  logicalType_(other.logicalType_),
 		  interval_(other.interval_),
 		  type_(other.type_),
 		  anonymous_(other.anonymous_),
@@ -135,6 +136,11 @@ public:
 		return value_.stringValue_;
 	}
 
+	// Explicit logical type accessors (see logicalType_).
+	inline void setLogicalType(const LogicalType& t) { logicalType_ = t; }
+	inline const LogicalType& getLogicalType() const { return logicalType_; }
+	inline bool hasExplicitLogicalType() const { return logicalType_.type() != LogicalTypeId::UNKNOWN; }
+
 	inline const IntervalTerm& getInterval()const {
 		return interval_;
 	}
@@ -165,6 +171,11 @@ private:
 
 	// Numeric Values
 	Value value_;
+	// Optional explicit logical type for a CONSTANT term. UNKNOWN means "derive
+	// from the value's physical type" (the default). Set when a constant must
+	// carry richer typing than its physical storage (e.g. a DATE folded from
+	// parquet statistics: physical INT32, but must render and type as DATE).
+	LogicalType logicalType_{};
 	// If it is interval the interval from to
 	IntervalTerm interval_{};
 	// Type of the term Constant/Variable/etc.

--- a/src/include/bumblebee/planner/filter/ConjunctionFilter.hpp
+++ b/src/include/bumblebee/planner/filter/ConjunctionFilter.hpp
@@ -46,6 +46,11 @@ public:
     FilterPropagateResult checkStatistics(BaseStatistics &stats) override;
     string toString(const string &column_name) override;
     bool equals(const TableFilter &other) const override;
+    // AND combination: every child may clear additional bits.
+    void filterRows(Vector &v, idx_t count, std::bitset<STANDARD_VECTOR_SIZE> &mask) override {
+        for (auto &child : childFilters_)
+            child->filterRows(v, count, mask);
+    }
 };
 
 

--- a/src/include/bumblebee/planner/filter/ConstantFilter.hpp
+++ b/src/include/bumblebee/planner/filter/ConstantFilter.hpp
@@ -33,6 +33,7 @@ public:
     FilterPropagateResult checkStatistics(BaseStatistics &stats) override;
     string toString(const string &column_name) override;
     bool equals(const TableFilter &other) const override;
+    void filterRows(Vector &v, idx_t count, std::bitset<STANDARD_VECTOR_SIZE> &mask) override;
 };
 
 

--- a/src/include/bumblebee/planner/filter/TableFilter.hpp
+++ b/src/include/bumblebee/planner/filter/TableFilter.hpp
@@ -17,9 +17,11 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
+#include <bitset>
 #include <cstdint>
 #include <unordered_map>
 
+#include "bumblebee/common/Constants.hpp"
 #include "bumblebee/common/TypeDefs.hpp"
 #include "bumblebee/storage/statistics/BaseStatistics.hpp"
 
@@ -27,6 +29,7 @@ namespace bumblebee{
 
 
 class BaseStatistics;
+class Vector;
 
 enum class TableFilterType : std::uint8_t {
     CONSTANT_COMPARISON = 0, // constant comparison (e.g. =C, >C, >=C, <C, <=C)
@@ -52,6 +55,14 @@ public:
     virtual string toString(const string &column_name) = 0;
     virtual bool equals(const TableFilter &other) const {
         return filterType_ != other.filterType_;
+    }
+
+    // Row-level evaluation at the scan: clear mask bits for rows of `v` (flat,
+    // already decoded) that PROVABLY fail the filter. Implementations must be
+    // conservative — a bit may only be cleared when the downstream pipeline
+    // filter would also reject the row (so NULLs and any uncertain case keep
+    // their bit set and are left to the pipeline). The default keeps all rows.
+    virtual void filterRows(Vector &v, idx_t count, std::bitset<STANDARD_VECTOR_SIZE> &mask) {
     }
 };
 

--- a/src/include/bumblebee/planner/rewriter/MetadataAggRewriter.hpp
+++ b/src/include/bumblebee/planner/rewriter/MetadataAggRewriter.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Davide Fuscà
+ *
+ * This file is part of BumbleBee.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "bumblebee/parser/statement/Rule.hpp"
+
+namespace bumblebee {
+
+class ClientContext;
+
+// Program-level rewrite that folds a plain COUNT(*) over an unfiltered
+// &read_parquet scan into a constant fact, reading the row count from the
+// Parquet file metadata instead of scanning the data.
+//
+// It is intentionally very conservative: it only fires when the row count is
+// provably COUNT(*) (the aggregated term is a constant in the scan rule head)
+// and there is no filter (single-atom bodies). Any query that does not match
+// the exact pattern is left untouched, so it cannot regress other queries.
+class MetadataAggRewriter {
+public:
+    explicit MetadataAggRewriter(ClientContext& context) : context_(context) {}
+
+    void rewrite(rules_vector_t& program);
+
+private:
+    ClientContext& context_;
+
+    // Resolve the parquet path(s) referenced by a &read_parquet atom and sum
+    // their row counts from metadata. Returns false (and leaves total unset)
+    // if the path cannot be resolved or any reader fails.
+    bool countRowsFromMetadata(Atom& readParquetAtom, idx_t& total);
+};
+
+} // namespace bumblebee

--- a/src/include/bumblebee/planner/rewriter/MetadataAggRewriter.hpp
+++ b/src/include/bumblebee/planner/rewriter/MetadataAggRewriter.hpp
@@ -23,6 +23,8 @@
 namespace bumblebee {
 
 class ClientContext;
+class Value;
+class LogicalType;
 
 // Program-level rewrite that folds a plain COUNT(*) over an unfiltered
 // &read_parquet scan into a constant fact, reading the row count from the
@@ -45,6 +47,14 @@ private:
     // their row counts from metadata. Returns false (and leaves total unset)
     // if the path cannot be resolved or any reader fails.
     bool countRowsFromMetadata(Atom& readParquetAtom, idx_t& total);
+
+    // Fold MIN(col)/MAX(col) over an unfiltered &read_parquet scan into constants
+    // read from parquet column statistics (numeric/temporal columns only). The
+    // folded constant carries the column's logical type so DATE/TIMESTAMP results
+    // format and type exactly as the un-folded query.
+    void foldMinMax(rules_vector_t& program);
+    bool minMaxFromMetadata(Atom& readParquetAtom, const string& aggVar, bool wantMin,
+                            Value& out, LogicalType& outType);
 };
 
 } // namespace bumblebee

--- a/src/include/bumblebee/storage/statistics/BaseStatistics.hpp
+++ b/src/include/bumblebee/storage/statistics/BaseStatistics.hpp
@@ -32,6 +32,7 @@ enum class FilterPropagateResult : uint8_t {
 };
 
 
+class Value;
 class BaseStatistics {
 public:
     explicit BaseStatistics(LogicalType type);
@@ -56,6 +57,10 @@ public:
     static std::unique_ptr<BaseStatistics> deserialize(Deserializer &source, const LogicalType &type);
     virtual void verify(Vector &vector, const SelectionVector &sel, idx_t count);
     void verify(Vector &vector, idx_t count);
+
+    // Type-safe min/max access without RTTI: numeric/temporal stats override and
+    // fill mn/mx; others (e.g. string) return false.
+    virtual bool numericMinMax(Value &mn, Value &mx) { return false; }
 
     virtual string toString();
 };

--- a/src/include/bumblebee/storage/statistics/NumericStatistics.hpp
+++ b/src/include/bumblebee/storage/statistics/NumericStatistics.hpp
@@ -44,6 +44,7 @@ public:
 	std::unique_ptr<BaseStatistics> copy() override;
 
 	string toString() override;
+	bool numericMinMax(Value &mn, Value &mx) override { mn = min_.clone(); mx = max_.clone(); return true; }
 
 private:
 

--- a/src/include/std_prelude.hpp
+++ b/src/include/std_prelude.hpp
@@ -1,0 +1,23 @@
+#pragma once
+// Force-included for every translation unit (see CMakeLists.txt).
+//
+// The codebase was originally compiled with toolchains (e.g. Apple/LLVM
+// libc++) whose standard headers transitively pull in many other standard
+// headers. libstdc++ (GCC) is stricter and does not, so building there fails
+// with "X is not a member of std" / "incomplete type" errors for symbols the
+// sources use without a direct include. Rather than scatter dozens of
+// individual includes across src/ and vendored third_party/, we provide the
+// commonly-relied-upon standard headers here in one place.
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+#include <cmath>
+#include <limits>
+#include <algorithm>
+#include <memory>
+#include <atomic>
+#include <functional>
+#include <queue>
+#include <stdexcept>
+#include <utility>
+#include <format>

--- a/src/parallel/TaskExecutor.cpp
+++ b/src/parallel/TaskExecutor.cpp
@@ -33,6 +33,9 @@ void TaskExecutor::executeForeverTask(ConcurrentQueue *queue_, std::atomic<bool>
         bool res = queue_->q.wait_dequeue_timed(task ,WAIT_TIMEOUT_USECS);
         // if res is false no data in the queue, continue to spin if marker is true
         if (!res) continue;
+        // a null task is a wake-up sentinel enqueued on shutdown: loop back so the
+        // marker check can terminate the thread without waiting for the timeout
+        if (!task) continue;
         // task to execute
         task->execute();
         // signal the scheduler that the task is completed
@@ -57,6 +60,12 @@ void TaskExecutor::stopThreadsAndJoin() {
 
     for (auto& marker: markers_) {
         marker->store(false);
+    }
+    // Wake any worker blocked in wait_dequeue_timed with a null sentinel per
+    // thread, so they observe the cleared marker immediately instead of waiting
+    // out the full dequeue timeout. This removes a ~100ms tail latency per query.
+    for (idx_t i = 0; i < threadsNumber_; ++i) {
+        queue_.q.enqueue(task_ptr_t(nullptr));
     }
     for (auto& thread: threads_) {
         thread->join();

--- a/src/parser/ParserInputBuilder.cpp
+++ b/src/parser/ParserInputBuilder.cpp
@@ -204,7 +204,7 @@ void ParserInputBuilder::setRuleDirective() {
             }
 
             // decrement as 0 is not found
-            colModifiers.push_back({.col_ = varColIndex[var], .modifier_ = orderModifiers_[i]});
+            colModifiers.push_back({.modifier_ = orderModifiers_[i], .col_ = varColIndex[var]});
         }
 
         currentRule.setModifiers(colModifiers);
@@ -1239,7 +1239,7 @@ void ParserInputBuilder::onSqlOrderCol() {
         safetyErrorMessage = "order by variable: '"+colVar+"' not found in the select. Please specify a variable in the head.";
     }
     BB_ASSERT(!orderModifiers_.empty());
-    ColModifier colModifier = {.col_ = idx, .modifier_ = orderModifiers_.back()};
+    ColModifier colModifier = {.modifier_ = orderModifiers_.back(), .col_ = idx};
     orderModifiers_.pop_back();
     sqlStatements_.back().getOrderby().addColModifier(colModifier);
 }
@@ -1258,7 +1258,7 @@ void ParserInputBuilder::onSQLLimit(char *number) {
     limit_ = 0;
     if (sqlStatements_.back().getOrderby().empty()) {
         // order by is empty because we have a limit create it
-        ColModifier cm = {.col_ = 0, .modifier_ = OrderType::ASCENDING};
+        ColModifier cm = {.modifier_ = OrderType::ASCENDING, .col_ = 0};
         sqlStatements_.back().getOrderby().addColModifier(cm);
     }
 }

--- a/src/parser/statement/Term.cpp
+++ b/src/parser/statement/Term.cpp
@@ -31,6 +31,7 @@ Term::Term(Term&& term) noexcept
     : negative_(term.negative_),
       interval_(term.interval_),
       value_(std::move(term.value_)),
+      logicalType_(term.logicalType_),
       type_(term.type_),
       anonymous_(term.anonymous_),
       parenthesized_(term.parenthesized_),
@@ -100,6 +101,7 @@ Term & Term::operator=(const Term &other) {
     parenthesized_ = other.parenthesized_;
     terms_ = other.terms_;
     operators_ = other.operators_ ;
+    logicalType_ = other.logicalType_;
     value_ = other.value_.cast(other.value_.ctype_);
     return *this;
 }

--- a/src/parser/statement/sql/SqlToDatalog.cpp
+++ b/src/parser/statement/sql/SqlToDatalog.cpp
@@ -634,7 +634,23 @@ Rule generateAggRules(const std::unordered_set<string>& groupVars, const std::un
     // constant would let the optimizer prune the column-less source, so materialize the body
     // into an aux predicate carrying the constant to keep the source row stream.
     bool anchored = !groupVars.empty() || aggVars.size() > countStarSelectIdxs.size();
-    bool countStarNeedsAux = hasCountStar && !anchored;
+
+    // A single filtered scan (one source atom + at least one filter/comparison) is
+    // also safe to inline: the filter references a source column, so the optimizer
+    // keeps the scan alive and the aggregate pipelines directly over it instead of
+    // materialising the whole (possibly wide) filtered column into an aux predicate
+    // just to count rows. Plain unfiltered SELECT COUNT(*) FROM t keeps the aux so
+    // the metadata count optimization (which folds the aux scan away) still applies,
+    // and joins (multiple sources) keep the aux to avoid pruning the row source.
+    idx_t sourceAtoms = 0, filterAtoms = 0;
+    for (auto& atom : rule.getBody()) {
+        auto at = atom.getType();
+        if (at == CLASSICAL || at == EXTERNAL) sourceAtoms++;
+        else if (at == BUILTIN) filterAtoms++;
+    }
+    bool inlinableFilteredScan = (sourceAtoms == 1 && filterAtoms >= 1);
+
+    bool countStarNeedsAux = hasCountStar && !anchored && !inlinableFilteredScan;
 
     string cstarVarName;
     Predicate* auxPred = nullptr;

--- a/src/planner/filter/ConstantFilter.cpp
+++ b/src/planner/filter/ConstantFilter.cpp
@@ -20,6 +20,8 @@
 #include "bumblebee/storage/statistics/NumericStatistics.hpp"
 #include "bumblebee/storage/statistics/StringStatistics.hpp"
 #include "bumblebee/common/types/Date.hpp"
+#include "bumblebee/common/types/Vector.hpp"
+#include "bumblebee/common/operator/ComparisonOperators.hpp"
 #include "bumblebee/common/NumericUtils.hpp"
 
 namespace bumblebee{
@@ -101,6 +103,102 @@ FilterPropagateResult ConstantFilter::checkStatistics(BaseStatistics &stats) {
             return ((StringStatistics &)stats).checkZonemap(comparisonType_, constant_.toString());
         }default:
             return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+    }
+}
+
+namespace {
+
+template <class T, class OP>
+void filterRowsLoop(Vector &v, const T constant, idx_t count, std::bitset<STANDARD_VECTOR_SIZE> &mask) {
+    auto data = FlatVector::getData<T>(v);
+    for (idx_t i = 0; i < count; i++) {
+        if (!mask[i]) continue;          // already filtered out (value may be undecoded)
+        if (!v.rowIsValid(i)) continue;  // NULL: must be left to the pipeline filter
+        if (!OP::operation(data[i], constant)) mask[i] = false;
+    }
+}
+
+template <class T>
+void filterRowsTypedOp(Binop op, Vector &v, const T constant, idx_t count, std::bitset<STANDARD_VECTOR_SIZE> &mask) {
+    switch (op) {
+        case EQUAL:         filterRowsLoop<T, Equals>(v, constant, count, mask); break;
+        case UNEQUAL:       filterRowsLoop<T, NotEquals>(v, constant, count, mask); break;
+        case LESS:          filterRowsLoop<T, LessThan>(v, constant, count, mask); break;
+        case LESS_OR_EQ:    filterRowsLoop<T, LessThanEquals>(v, constant, count, mask); break;
+        case GREATER:       filterRowsLoop<T, GreaterThan>(v, constant, count, mask); break;
+        case GREATER_OR_EQ: filterRowsLoop<T, GreaterThanEquals>(v, constant, count, mask); break;
+        default: break; // unknown comparison: keep all rows
+    }
+}
+
+} // namespace
+
+void ConstantFilter::filterRows(Vector &v, idx_t count, std::bitset<STANDARD_VECTOR_SIZE> &mask) {
+    // Evaluate `column <op> constant` on the decoded values and clear the mask
+    // bits of rows that provably fail. This must be a subset of what the
+    // downstream pipeline filter rejects, so every uncertain case (NULLs,
+    // non-representable constants, unhandled types) keeps its bit set.
+    const auto physType = v.getType();
+    const auto logicalId = v.getLogicalType().type();
+
+    if (logicalId == LogicalTypeId::TIMESTAMP) {
+        return; // mirror checkStatistics: timestamp constants are not handled
+    }
+    if (logicalId == LogicalTypeId::DATE ||
+        (logicalId == LogicalTypeId::DECIMAL && constant_.getPhysicalType() != physType)) {
+        // mirror checkStatistics: convert the constant (string date -> days,
+        // integer -> scaled decimal) only in the cases the statistics check
+        // converts; bail out (keep all rows) when it isn't convertible
+        Value converted;
+        if (!castConstantForStats(constant_, v.getLogicalType(), converted)) return;
+        switch (physType) {
+            case PhysicalType::SMALLINT: filterRowsTypedOp<int16_t>(comparisonType_, v, converted.getValueUnsafe<int16_t>(), count, mask); break;
+            case PhysicalType::INTEGER:  filterRowsTypedOp<int32_t>(comparisonType_, v, converted.getValueUnsafe<int32_t>(), count, mask); break;
+            case PhysicalType::BIGINT:   filterRowsTypedOp<int64_t>(comparisonType_, v, converted.getValueUnsafe<int64_t>(), count, mask); break;
+            default: break;
+        }
+        return;
+    }
+    if (logicalId == LogicalTypeId::DECIMAL) {
+        // same physical type: the constant already carries the scaled
+        // representation (as in checkStatistics), compare it directly
+        switch (physType) {
+            case PhysicalType::SMALLINT: filterRowsTypedOp<int16_t>(comparisonType_, v, constant_.getValueUnsafe<int16_t>(), count, mask); break;
+            case PhysicalType::INTEGER:  filterRowsTypedOp<int32_t>(comparisonType_, v, constant_.getValueUnsafe<int32_t>(), count, mask); break;
+            case PhysicalType::BIGINT:   filterRowsTypedOp<int64_t>(comparisonType_, v, constant_.getValueUnsafe<int64_t>(), count, mask); break;
+            default: break;
+        }
+        return;
+    }
+    if (physType == PhysicalType::STRING) {
+        const string constStr = constant_.toString();
+        const string_t cst(constStr.c_str(), (uint32_t)constStr.size());
+        filterRowsTypedOp<string_t>(comparisonType_, v, cst, count, mask);
+        return;
+    }
+
+    // Numeric columns: cast the constant to the column type, but only filter
+    // when the cast is exact (round-trips back to the original value).
+    // Otherwise a truncated constant (e.g. X < 10.5 against an int column)
+    // would reject rows the pipeline filter keeps.
+    Value casted, roundTrip;
+    string error;
+    if (!constant_.tryCastAs(physType, casted, &error)) return;
+    if (!casted.tryCastAs(constant_.getPhysicalType(), roundTrip, &error)) return;
+    if (!(roundTrip == constant_)) return;
+
+    switch (physType) {
+        case PhysicalType::TINYINT:   filterRowsTypedOp<int8_t>(comparisonType_, v, casted.getValueUnsafe<int8_t>(), count, mask); break;
+        case PhysicalType::SMALLINT:  filterRowsTypedOp<int16_t>(comparisonType_, v, casted.getValueUnsafe<int16_t>(), count, mask); break;
+        case PhysicalType::INTEGER:   filterRowsTypedOp<int32_t>(comparisonType_, v, casted.getValueUnsafe<int32_t>(), count, mask); break;
+        case PhysicalType::BIGINT:    filterRowsTypedOp<int64_t>(comparisonType_, v, casted.getValueUnsafe<int64_t>(), count, mask); break;
+        case PhysicalType::UTINYINT:  filterRowsTypedOp<uint8_t>(comparisonType_, v, casted.getValueUnsafe<uint8_t>(), count, mask); break;
+        case PhysicalType::USMALLINT: filterRowsTypedOp<uint16_t>(comparisonType_, v, casted.getValueUnsafe<uint16_t>(), count, mask); break;
+        case PhysicalType::UINTEGER:  filterRowsTypedOp<uint32_t>(comparisonType_, v, casted.getValueUnsafe<uint32_t>(), count, mask); break;
+        case PhysicalType::UBIGINT:   filterRowsTypedOp<uint64_t>(comparisonType_, v, casted.getValueUnsafe<uint64_t>(), count, mask); break;
+        case PhysicalType::FLOAT:     filterRowsTypedOp<float>(comparisonType_, v, casted.getValueUnsafe<float>(), count, mask); break;
+        case PhysicalType::DOUBLE:    filterRowsTypedOp<double>(comparisonType_, v, casted.getValueUnsafe<double>(), count, mask); break;
+        default: break; // unhandled type: keep all rows
     }
 }
 

--- a/src/planner/optimizer/PhysicalOptimizer.cpp
+++ b/src/planner/optimizer/PhysicalOptimizer.cpp
@@ -941,8 +941,11 @@ void PhysicalOptimizer::generateOutputPhysicalAtom(Rule &rule, patom_ptr_t &sink
             BB_ASSERT(function);
             aggFunctions.push_back((AggregateFunction*) function.get());
         }
-        // get source cardinality
-        auto estimatedSourceCardinality = source->getMaxThreads() * MORSEL_SIZE;
+        // get source cardinality (upper bound on number of groups) so the
+        // aggregation hash table is pre-sized and avoids repeated resize+rehash.
+        // For parquet this is the exact metadata row count; otherwise a coarse
+        // estimate from the scan's parallelism granularity.
+        auto estimatedSourceCardinality = source->getEstimatedCardinality();
         ptSink->createPartitionedAggHashTable(aggInfo.groups_, aggInfo.payloads_, aggFunctions, estimatedSourceCardinality);
         if (aggInfo.distinct_)
             ptSink->getPartitionedAggHashTable()->setDistinct();

--- a/src/planner/optimizer/PhysicalOptimizer.cpp
+++ b/src/planner/optimizer/PhysicalOptimizer.cpp
@@ -941,11 +941,8 @@ void PhysicalOptimizer::generateOutputPhysicalAtom(Rule &rule, patom_ptr_t &sink
             BB_ASSERT(function);
             aggFunctions.push_back((AggregateFunction*) function.get());
         }
-        // get source cardinality (upper bound on number of groups) so the
-        // aggregation hash table is pre-sized and avoids repeated resize+rehash.
-        // For parquet this is the exact metadata row count; otherwise a coarse
-        // estimate from the scan's parallelism granularity.
-        auto estimatedSourceCardinality = source->getEstimatedCardinality();
+        // get source cardinality
+        auto estimatedSourceCardinality = source->getMaxThreads() * MORSEL_SIZE;
         ptSink->createPartitionedAggHashTable(aggInfo.groups_, aggInfo.payloads_, aggFunctions, estimatedSourceCardinality);
         if (aggInfo.distinct_)
             ptSink->getPartitionedAggHashTable()->setDistinct();

--- a/src/planner/optimizer/PhysicalOptimizer.cpp
+++ b/src/planner/optimizer/PhysicalOptimizer.cpp
@@ -220,8 +220,13 @@ void PhysicalOptimizer::findColsAndTypesBuiltin(Atom &atom) {
         BB_ASSERT(left.getType() == VARIABLE);
         BB_ASSERT(right.getType() == CONSTANT);
         BB_ASSERT(!colsMap_.contains(left.getVariable()));
-        // we need to calculate the type of the left side
-        typesMap_[left.getVariable()] = {right.getPhysicalType()};
+        // we need to calculate the type of the left side. A folded constant may
+        // carry an explicit logical type (e.g. DATE/TIMESTAMP from parquet
+        // metadata) that must be preserved so the result formats correctly.
+        if (right.hasExplicitLogicalType())
+            typesMap_[left.getVariable()] = right.getLogicalType();
+        else
+            typesMap_[left.getVariable()] = {right.getPhysicalType()};
         colsMap_[left.getVariable()] = colsMap_.size();
         vars.insert(vars.begin(),left.getVariable());
     }else if (atom.isOrBuiltin() || atom.getBinop() != ASSIGNMENT) {

--- a/src/planner/rewriter/AggregatesRewriter.cpp
+++ b/src/planner/rewriter/AggregatesRewriter.cpp
@@ -151,13 +151,13 @@ void AggregatesRewriter::rewrite(rules_vector_t &program) {
             Predicate *predicate = clientContext_.defaultSchema_.createPredicate(&clientContext_, newPredName.c_str(), info.terms_.size());
             predicate->setInternal(true);
             if (createAuxRule) {
-                Atom head = Atom::createClassicalAtom(predicate, std::move(vector(terms)));
+                Atom head = Atom::createClassicalAtom(predicate, std::move(vector<Term>(terms)));
                 Rule newRule;
                 newRule.addAtomInHead(std::move(head));
                 newRule.setBody(a.getAggsAtoms());
                 program.push_back(std::move(newRule));
             }
-            auto newAtom =  Atom::createClassicalAtom(predicate, std::move(vector(terms)));
+            auto newAtom =  Atom::createClassicalAtom(predicate, std::move(vector<Term>(terms)));
             a.getAggsAtoms().clear();
             a.getAggsAtoms().push_back(std::move(newAtom));
         }

--- a/src/planner/rewriter/MetadataAggRewriter.cpp
+++ b/src/planner/rewriter/MetadataAggRewriter.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2025 Davide Fuscà
+ *
+ * This file is part of BumbleBee.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "bumblebee/planner/rewriter/MetadataAggRewriter.hpp"
+
+#include <set>
+#include <unordered_map>
+
+#include "bumblebee/ClientContext.hpp"
+#include "bumblebee/common/Log.hpp"
+#include "bumblebee/common/StringUtils.hpp"
+#include "bumblebee/common/parquet/ParquetReader.hpp"
+
+namespace bumblebee {
+
+static constexpr const char* READ_PARQUET = "&read_parquet";
+
+bool MetadataAggRewriter::countRowsFromMetadata(Atom& atom, idx_t& total) {
+    if (atom.getType() != EXTERNAL) return false;
+    if (atom.getExternalFunctionName() != READ_PARQUET) return false;
+    auto& inputs = atom.getInputValues();
+    if (inputs.size() != 1) return false;
+
+    string folder = inputs[0].toString();
+    auto& fs = *context_.fileSystem_;
+
+    vector<string> files;
+    try {
+        if (!StringUtils::hasGlob(folder)) {
+            if (fs.fileExists(folder)) {
+                files.push_back(folder);
+            } else if (fs.directoryExists(folder)) {
+                auto sep = fs.getFileSeparator();
+                files = fs.glob(folder + sep + "**" + sep + "*.parquet");
+            } else {
+                return false;
+            }
+        } else {
+            files = fs.glob(folder);
+        }
+
+        if (files.empty()) return false;
+
+        idx_t sum = 0;
+        for (auto& f : files) {
+            ParquetReader reader(context_, f, ParquetOptions{});
+            sum += reader.numRows();
+        }
+        total = sum;
+        return true;
+    } catch (...) {
+        // Any failure resolving/reading metadata: skip the optimization safely.
+        return false;
+    }
+}
+
+void MetadataAggRewriter::rewrite(rules_vector_t& program) {
+    // Index predicate definitions (in heads) and body uses (classical body
+    // atoms and aggregate-body classical atoms). Used to verify the scan
+    // predicate is defined once and referenced only by the count rule.
+    std::unordered_map<string, vector<idx_t>> defs;
+    std::unordered_map<string, int> bodyUses;
+
+    auto recordBodyUse = [&](Atom& a) {
+        if (a.getType() == CLASSICAL && a.getPredicate())
+            bodyUses[a.getPredicate()->getName()]++;
+        if (a.getType() == AGGREGATE)
+            for (auto& sub : a.getAggsAtoms())
+                if (sub.getType() == CLASSICAL && sub.getPredicate())
+                    bodyUses[sub.getPredicate()->getName()]++;
+    };
+
+    for (idx_t i = 0; i < program.size(); ++i) {
+        for (auto& h : program[i].getHead())
+            if (h.getType() == CLASSICAL && h.getPredicate())
+                defs[h.getPredicate()->getName()].push_back(i);
+        for (auto& b : program[i].getBody())
+            recordBodyUse(b);
+    }
+
+    std::set<idx_t> rulesToErase;
+
+    for (idx_t i = 0; i < program.size(); ++i) {
+        Rule& rcount = program[i];
+
+        // R_count: head single atom, body a single COUNT aggregate, no groups.
+        if (rcount.getHead().size() != 1 || rcount.getBody().size() != 1) continue;
+        Atom& agg = rcount.getBody()[0];
+        if (agg.getType() != AGGREGATE) continue;
+        auto& funcs = agg.getAggregateFunctions();
+        if (funcs.size() != 1 || funcs[0] != COUNT) continue;
+        if (agg.hasExplicitGroups()) continue;
+
+        // The aggregate must range over exactly one classical predicate atom
+        // (the materialised scan). A filter would appear as an extra atom.
+        auto& aggBody = agg.getAggsAtoms();
+        if (aggBody.size() != 1) continue;
+        Atom& scanRef = aggBody[0];
+        if (scanRef.getType() != CLASSICAL || !scanRef.getPredicate()) continue;
+
+        // Counted term must be a single variable.
+        auto& aggTerms = agg.getAggTerms();
+        if (aggTerms.empty() || aggTerms[0].getType() != VARIABLE) continue;
+        const string countedVar = aggTerms[0].getVariable();
+
+        // Find the position of the counted variable inside the scan atom.
+        auto& scanRefTerms = scanRef.getTerms();
+        idx_t pos = scanRefTerms.size();
+        for (idx_t k = 0; k < scanRefTerms.size(); ++k) {
+            if (scanRefTerms[k].getType() == VARIABLE && scanRefTerms[k].getVariable() == countedVar) {
+                pos = k;
+                break;
+            }
+        }
+        if (pos == scanRefTerms.size()) continue;
+
+        // The scan predicate must be defined by exactly one rule and used only
+        // here, so that we can prove COUNT(*) and safely drop the scan rule.
+        const string scanPred = scanRef.getPredicate()->getName();
+        auto defIt = defs.find(scanPred);
+        if (defIt == defs.end() || defIt->second.size() != 1) continue;
+        idx_t scanRuleIdx = defIt->second[0];
+        if (scanRuleIdx == i) continue;
+        if (bodyUses[scanPred] != 1) continue;
+
+        Rule& rscan = program[scanRuleIdx];
+        // R_scan: head P(...), body a single &read_parquet atom (no filter).
+        if (rscan.getHead().size() != 1 || rscan.getBody().size() != 1) continue;
+        Atom& scanHead = rscan.getHead()[0];
+        if (scanHead.getTerms().size() <= pos) continue;
+        // COUNT(*) proof: the counted position holds a constant in the scan head
+        // (i.e. each row contributes a constant marker, not a real column value
+        // as COUNT(DISTINCT col) would).
+        if (scanHead.getTerms()[pos].getType() != CONSTANT) continue;
+
+        Atom& scanAtom = rscan.getBody()[0];
+        idx_t total = 0;
+        if (!countRowsFromMetadata(scanAtom, total)) continue;
+
+        // The head must expose only the aggregate result variable; replace it
+        // with the constant row count, turning the rule into a fact.
+        auto assignTerms = agg.getAssignmentTerms();
+        if (assignTerms.size() != 1 || assignTerms[0].getType() != VARIABLE) continue;
+        const string resultVar = assignTerms[0].getVariable();
+
+        Atom& head = rcount.getHead()[0];
+        if (head.getType() != CLASSICAL || !head.getPredicate()) continue;
+        bool ok = true;
+        terms_vector_t newTerms;
+        for (auto& t : head.getTerms()) {
+            if (t.getType() == VARIABLE) {
+                if (t.getVariable() != resultVar) { ok = false; break; }
+                newTerms.push_back(Term::createSmallestConstantNumericTerm((unsigned long long) total));
+            } else {
+                newTerms.push_back(t);
+            }
+        }
+        if (!ok) continue;
+
+        Predicate* headPred = head.getPredicate();
+        Atom newHead = Atom::createClassicalAtom(headPred, std::move(newTerms));
+
+        auto& headVec = rcount.getHead();
+        headVec.clear();
+        headVec.push_back(std::move(newHead));
+        rcount.getBody().clear();
+
+        rulesToErase.insert(scanRuleIdx);
+
+        LOG_DEBUG("MetadataAggRewriter: folded COUNT(*) over %s into constant %llu",
+                  scanPred.c_str(), (unsigned long long) total);
+    }
+
+    // Erase the now-dead scan rules (descending order to keep indices valid).
+    for (auto it = rulesToErase.rbegin(); it != rulesToErase.rend(); ++it)
+        program.erase(program.begin() + *it);
+}
+
+} // namespace bumblebee

--- a/src/planner/rewriter/MetadataAggRewriter.cpp
+++ b/src/planner/rewriter/MetadataAggRewriter.cpp
@@ -20,6 +20,7 @@
 
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "bumblebee/ClientContext.hpp"
 #include "bumblebee/common/Log.hpp"
@@ -69,7 +70,128 @@ bool MetadataAggRewriter::countRowsFromMetadata(Atom& atom, idx_t& total) {
     }
 }
 
+bool MetadataAggRewriter::minMaxFromMetadata(Atom& scanAtom, const string& aggVar, bool wantMin,
+                                             Value& out, LogicalType& outType) {
+    if (scanAtom.getType() != EXTERNAL) return false;
+    if (scanAtom.getExternalFunctionName() != READ_PARQUET) return false;
+    auto& inputs = scanAtom.getInputValues();
+    if (inputs.size() != 1) return false;
+    string folder = inputs[0].toString();
+    auto& fs = *context_.fileSystem_;
+    try {
+        vector<string> files;
+        if (!StringUtils::hasGlob(folder)) {
+            if (fs.fileExists(folder)) files.push_back(folder);
+            else if (fs.directoryExists(folder)) {
+                auto sep = fs.getFileSeparator();
+                files = fs.glob(folder + sep + "**" + sep + "*.parquet");
+            } else return false;
+        } else {
+            files = fs.glob(folder);
+        }
+        if (files.size() != 1) return false;   // single file only (avoids cross-file merge)
+
+        // Map the aggregate variable to its real parquet column via columns_mapping.
+        string realCol = aggVar;
+        auto& named = scanAtom.getNamedParamters();
+        auto it = named.find("columns_mapping");
+        if (it != named.end()) {
+            auto mapping = StringUtils::parseColMapping(it->second.toString(), {aggVar});
+            auto mit = mapping.find(aggVar);
+            if (mit != mapping.end()) realCol = mit->second;
+        }
+
+        ParquetReader reader(context_, files[0], ParquetOptions{});
+        idx_t colIdx = reader.columnIndex(StringUtils::normalizeColumnName(realCol));
+        if (colIdx == (idx_t)-1) return false;
+        PhysicalType pt;
+        auto stats = ParquetReader::readStatistics(reader, pt, colIdx, reader.getFileMetadata());
+        if (!stats) return false;
+        Value mn, mx;
+        if (!stats->numericMinMax(mn, mx)) return false;   // numeric/temporal columns only
+        out = (wantMin ? mn : mx).clone();
+        outType = reader.columnLogicalType(colIdx);        // logical type (DATE/TIMESTAMP/...)
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+void MetadataAggRewriter::foldMinMax(rules_vector_t& program) {
+    for (auto& rule : program) {
+        if (rule.getHead().size() != 1 || rule.getBody().size() != 1) continue;
+        Atom& agg = rule.getBody()[0];
+        if (agg.getType() != AGGREGATE || agg.hasExplicitGroups()) continue;
+
+        // The aggregate body must be exactly one unfiltered &read_parquet scan.
+        auto& aggBody = agg.getAggsAtoms();
+        if (aggBody.size() != 1) continue;
+        Atom& scan = aggBody[0];
+        if (scan.getType() != EXTERNAL || scan.getExternalFunctionName() != READ_PARQUET) continue;
+
+        // Every aggregate function must be MIN or MAX (COUNT is handled separately).
+        auto& funcs = agg.getAggregateFunctions();
+        if (funcs.empty()) continue;
+        bool allMinMax = true;
+        for (auto f : funcs) if (f != MIN && f != MAX) { allMinMax = false; break; }
+        if (!allMinMax) continue;
+
+        auto& aggTerms = agg.getAggTerms();
+        auto assignTerms = agg.getAssignmentTerms();
+        if (assignTerms.size() != funcs.size() || aggTerms.size() < funcs.size()) continue;
+
+        // The head is rebuilt by matching head variables to assignment-result
+        // variables by name. If two aggregates share an assignment variable
+        // (e.g. MIN and MAX of the same column with no SQL alias) the mapping is
+        // ambiguous, so skip the fold and let the normal aggregate path run.
+        bool uniqueAssign = true;
+        std::unordered_set<string> seenAssign;
+        for (auto& at : assignTerms) {
+            if (at.getType() != VARIABLE || !seenAssign.insert(at.getVariable()).second) {
+                uniqueAssign = false; break;
+            }
+        }
+        if (!uniqueAssign) continue;
+
+        // result var -> (value, logical type)
+        std::unordered_map<string, std::pair<Value, LogicalType>> resultConst;
+        bool ok = true;
+        for (idx_t i = 0; i < funcs.size(); ++i) {
+            if (aggTerms[i].getType() != VARIABLE || assignTerms[i].getType() != VARIABLE) { ok = false; break; }
+            Value v; LogicalType lt;
+            if (!minMaxFromMetadata(scan, aggTerms[i].getVariable(), funcs[i] == MIN, v, lt)) { ok = false; break; }
+            resultConst.emplace(assignTerms[i].getVariable(), std::make_pair(std::move(v), lt));
+        }
+        if (!ok) continue;
+
+        Atom& head = rule.getHead()[0];
+        if (head.getType() != CLASSICAL || !head.getPredicate()) continue;
+        terms_vector_t newTerms;
+        bool hok = true;
+        for (auto& t : head.getTerms()) {
+            if (t.getType() == VARIABLE) {
+                auto rit = resultConst.find(t.getVariable());
+                if (rit == resultConst.end()) { hok = false; break; }
+                Value vcopy = rit->second.first.clone();
+                Term ct(vcopy);
+                ct.setLogicalType(rit->second.second);   // preserve DATE/etc. formatting + typing
+                newTerms.push_back(std::move(ct));
+            } else {
+                newTerms.push_back(t);
+            }
+        }
+        if (!hok) continue;
+
+        Predicate* hp = head.getPredicate();
+        Atom newHead = Atom::createClassicalAtom(hp, std::move(newTerms));
+        rule.getHead().clear();
+        rule.getHead().push_back(std::move(newHead));
+        rule.getBody().clear();
+    }
+}
+
 void MetadataAggRewriter::rewrite(rules_vector_t& program) {
+    foldMinMax(program);
     // Index predicate definitions (in heads) and body uses (classical body
     // atoms and aggregate-body classical atoms). Used to verify the scan
     // predicate is defined once and referenced only by the count rule.

--- a/test/unit/bumblebee/common/parquet_reader/parquet_test.cpp
+++ b/test/unit/bumblebee/common/parquet_reader/parquet_test.cpp
@@ -253,7 +253,9 @@ TEST_F(ParquetScanTest, DecimalFilterAllOneColParquetScanTest1) {
     auto tableFilters = std::make_unique<TableFilterSet>();
     auto filter = std::make_unique<ConstantFilter>(Binop::EQUAL,  getConstantValue(1,0, types));
     tableFilters->pushFilter(0, std::move(filter));
-    testParquetReader(file, {}, {}, {}, tableFilters.get());
+    // the scan applies filters per row (not only per row group): the column
+    // holds 1.00 .. 24.00, so exactly one row matches value = 1
+    testParquetReaderCount(file, 1, {}, {}, {}, tableFilters.get());
 }
 
 TEST_F(ParquetScanTest, DecimalFilterAllOneColParquetScanTest2) {
@@ -272,8 +274,9 @@ TEST_F(ParquetScanTest, TPCHLineItemFiltersParquetScanTest1) {
     auto tableFilters = std::make_unique<TableFilterSet>();
     auto filter = std::make_unique<ConstantFilter>(Binop::EQUAL,  getConstantValue(1,0, types));
     tableFilters->pushFilter(0, std::move(filter));
-    // expected 122880 (first row group contains first column equal to 1)
-    testParquetReaderCount(file, 122880, {}, {}, {}, tableFilters.get());
+    // the scan applies filters per row (not only per row group): lineitem has
+    // exactly 6 rows with l_orderkey = 1
+    testParquetReaderCount(file, 6, {}, {}, {}, tableFilters.get());
 }
 
 TEST_F(ParquetScanTest, TPCHLineItemFiltersParquetScanTest2) {

--- a/test/unit/bumblebee/execution/topnheap_test.cpp
+++ b/test/unit/bumblebee/execution/topnheap_test.cpp
@@ -105,59 +105,59 @@ protected:
 TEST_F(TopNHeapTest, CreateTop10neColNumeric) {
 
     topNChunksTest(1, {PhysicalType::UINTEGER, PhysicalType::INTEGER, PhysicalType::FLOAT, PhysicalType::DOUBLE}, {
-        {.col_ = 1, .modifier_ = OrderType::ASCENDING}
+        {.modifier_ = OrderType::ASCENDING, .col_ = 1}
     }, 10);
 }
 
 TEST_F(TopNHeapTest, CreateTop10TwoColNumeric) {
 
     topNChunksTest(1, {PhysicalType::UINTEGER, PhysicalType::INTEGER, PhysicalType::FLOAT, PhysicalType::DOUBLE}, {
-        {.col_ = 1, .modifier_ = OrderType::ASCENDING},
-        {.col_ = 3, .modifier_ = OrderType::DESCENDING}
+        {.modifier_ = OrderType::ASCENDING, .col_ = 1},
+        {.modifier_ = OrderType::DESCENDING, .col_ = 3}
     }, 10);
 }
 
 TEST_F(TopNHeapTest, TopNMultipleChunksMixedTypes) {
     topNChunksTest(2, {PhysicalType::UINTEGER, PhysicalType::STRING, PhysicalType::DOUBLE}, {
-        {.col_ = 0, .modifier_ = OrderType::DESCENDING},
+        {.modifier_ = OrderType::DESCENDING, .col_ = 0},
     }, 3);
 }
 
 TEST_F(TopNHeapTest, TopNStringAndNumericAllDescending) {
     topNChunksTest(3, {PhysicalType::STRING, PhysicalType::INTEGER, PhysicalType::FLOAT}, {
-        {.col_ = 0, .modifier_ = OrderType::DESCENDING},
-        {.col_ = 1, .modifier_ = OrderType::DESCENDING},
-        {.col_ = 2, .modifier_ = OrderType::DESCENDING}
+        {.modifier_ = OrderType::DESCENDING, .col_ = 0},
+        {.modifier_ = OrderType::DESCENDING, .col_ = 1},
+        {.modifier_ = OrderType::DESCENDING, .col_ = 2}
     }, 5);
 }
 
 TEST_F(TopNHeapTest, TopNLimitGreaterThanRows) {
     topNChunksTest(2, {PhysicalType::INTEGER, PhysicalType::STRING}, {
-        {.col_ = 1, .modifier_ = OrderType::ASCENDING}
+        {.modifier_ = OrderType::ASCENDING, .col_ = 1}
     }, 100); // limit > total rows
 }
 
 TEST_F(TopNHeapTest, TopNAllAscendingMixedTypes) {
     topNChunksTest(4, {PhysicalType::STRING, PhysicalType::DOUBLE, PhysicalType::UINTEGER}, {
-        {.col_ = 0, .modifier_ = OrderType::ASCENDING},
-        {.col_ = 1, .modifier_ = OrderType::ASCENDING},
-        {.col_ = 2, .modifier_ = OrderType::ASCENDING}
+        {.modifier_ = OrderType::ASCENDING, .col_ = 0},
+        {.modifier_ = OrderType::ASCENDING, .col_ = 1},
+        {.modifier_ = OrderType::ASCENDING, .col_ = 2}
     }, 8);
 }
 
 TEST_F(TopNHeapTest, TopNComplexModifiers) {
     topNChunksTest(6, {PhysicalType::FLOAT, PhysicalType::STRING, PhysicalType::INTEGER, PhysicalType::DOUBLE}, {
-        {.col_ = 2, .modifier_ = OrderType::DESCENDING},
-        {.col_ = 1, .modifier_ = OrderType::ASCENDING},
-        {.col_ = 3, .modifier_ = OrderType::DESCENDING}
+        {.modifier_ = OrderType::DESCENDING, .col_ = 2},
+        {.modifier_ = OrderType::ASCENDING, .col_ = 1},
+        {.modifier_ = OrderType::DESCENDING, .col_ = 3}
     }, 3);
 }
 
 TEST_F(TopNHeapTest, TopNAllStringColumns) {
     topNChunksTest(4, {PhysicalType::STRING, PhysicalType::STRING, PhysicalType::STRING}, {
-        {.col_ = 0, .modifier_ = OrderType::ASCENDING},
-        {.col_ = 1, .modifier_ = OrderType::DESCENDING},
-        {.col_ = 2, .modifier_ = OrderType::ASCENDING}
+        {.modifier_ = OrderType::ASCENDING, .col_ = 0},
+        {.modifier_ = OrderType::DESCENDING, .col_ = 1},
+        {.modifier_ = OrderType::ASCENDING, .col_ = 2}
     }, 6);
 }
 
@@ -165,9 +165,9 @@ TEST_F(TopNHeapTest, TopNComplexModifiersCombineSameChunks) {
     auto randomChunks = 3;
     vector<LogicalType> types = {LogicalTypeId::FLOAT, LogicalTypeId::STRING, LogicalTypeId::INTEGER, LogicalTypeId::DOUBLE};
     vector<ColModifier> modifiers ={
-        {.col_ = 2, .modifier_ = OrderType::DESCENDING},
-        {.col_ = 1, .modifier_ = OrderType::ASCENDING},
-        {.col_ = 3, .modifier_ = OrderType::DESCENDING}
+        {.modifier_ = OrderType::DESCENDING, .col_ = 2},
+        {.modifier_ = OrderType::ASCENDING, .col_ = 1},
+        {.modifier_ = OrderType::DESCENDING, .col_ = 3}
     };
     auto limit = 100;
 
@@ -201,8 +201,8 @@ TEST_F(TopNHeapTest, TopNComplexModifiersCombineDifferentChunks) {
     auto randomChunks = 10;
     vector<LogicalType> types = {LogicalTypeId::STRING, LogicalTypeId::DOUBLE, LogicalTypeId::UINTEGER};
     vector<ColModifier> modifiers ={
-        {.col_ = 2, .modifier_ = OrderType::DESCENDING},
-        {.col_ = 1, .modifier_ = OrderType::ASCENDING},
+        {.modifier_ = OrderType::DESCENDING, .col_ = 2},
+        {.modifier_ = OrderType::ASCENDING, .col_ = 1},
     };
     auto limit = 800;
 

--- a/test/unit/bumblebee/function/write_csv_test.cpp
+++ b/test/unit/bumblebee/function/write_csv_test.cpp
@@ -31,7 +31,7 @@ using namespace bumblebee;
 class WriteCSVSCanTest : public ::testing::Test {
 protected:
     ClientContext context;
-    mutex mutex;
+    mutex mutex_;
 
     struct WriteParams {
         std::string sep = ",";

--- a/test/unit/third_party/hll.cpp
+++ b/test/unit/third_party/hll.cpp
@@ -75,7 +75,8 @@ TEST_F(HyperLogLogTest, MergeTwoDistinctHLLs) {
     hll_add(hll2, (unsigned char*)e2, strlen(e2));
     hll_add(hll2, (unsigned char*)e3, strlen(e2));
 
-    robj* merged = hll_merge((robj*[]){hll1, hll2}, 2);
+    robj* mergeInputs[] = {hll1, hll2};
+    robj* merged = hll_merge(mergeInputs, 2);
     ASSERT_NE(merged, nullptr);
 
     size_t count = 0;

--- a/third_party/utf8proc/utf8proc_wrapper.cpp
+++ b/third_party/utf8proc/utf8proc_wrapper.cpp
@@ -32,15 +32,35 @@ static void AssignInvalidUTF8Reason(UnicodeInvalidReason *invalid_reason, size_t
 
 UnicodeType Utf8Proc::Analyze(const char *s, size_t len, UnicodeInvalidReason *invalid_reason, size_t *invalid_pos) {
 	UnicodeType type = UnicodeType::ASCII;
-	char c;
-	for (size_t i = 0; i < len; i++) {
-		c = s[i];
+	// Word-at-a-time fast path: most strings are pure ASCII, so validate 8 bytes
+	// per step. A word is a run of plain ASCII iff no byte has the high bit set and
+	// no byte is NUL. The SWAR NUL test is the classic (w - 0x01..) & ~w & 0x80..
+	// trick. Any word failing either test falls through to the byte-precise loop
+	// below (which also handles all multi-byte sequences), so behaviour - including
+	// the exact invalid reason and position - is identical to the scalar scan.
+	constexpr uint64_t HIGH_BITS = 0x8080808080808080ULL;
+	constexpr uint64_t LOW_ONES = 0x0101010101010101ULL;
+	size_t i = 0;
+	for (;;) {
+		while (i + 8 <= len) {
+			uint64_t w;
+			memcpy(&w, s + i, 8);
+			if ((w & HIGH_BITS) || ((((w - LOW_ONES) & ~w) & HIGH_BITS))) {
+				break;
+			}
+			i += 8;
+		}
+		if (i >= len) {
+			break;
+		}
+		char c = s[i];
 		if (c == '\0') {
 			AssignInvalidUTF8Reason(invalid_reason, invalid_pos, i, UnicodeInvalidReason::NULL_BYTE);
 			return UnicodeType::INVALID;
 		}
 		// 1 Byte / ASCII
 		if ((c & 0x80) == 0) {
+			i++;
 			continue;
 		}
 		type = UnicodeType::UNICODE;
@@ -49,6 +69,7 @@ UnicodeType Utf8Proc::Analyze(const char *s, size_t len, UnicodeInvalidReason *i
 			return UnicodeType::INVALID;
 		}
 		if ((c & 0xE0) == 0xC0) {
+			i++;
 			continue;
 		}
 		if ((s[++i] & 0xC0) != 0x80) {
@@ -56,6 +77,7 @@ UnicodeType Utf8Proc::Analyze(const char *s, size_t len, UnicodeInvalidReason *i
 			return UnicodeType::INVALID;
 		}
 		if ((c & 0xF0) == 0xE0) {
+			i++;
 			continue;
 		}
 		if ((s[++i] & 0xC0) != 0x80) {
@@ -63,6 +85,7 @@ UnicodeType Utf8Proc::Analyze(const char *s, size_t len, UnicodeInvalidReason *i
 			return UnicodeType::INVALID;
 		}
 		if ((c & 0xF8) == 0xF0) {
+			i++;
 			continue;
 		}
 		AssignInvalidUTF8Reason(invalid_reason, invalid_pos, i, UnicodeInvalidReason::BYTE_MISMATCH);


### PR DESCRIPTION

## A1. ValidityMask data structure
- **Goal:** Per-value NULL bitmask with a zero-cost "no nulls" common case.
- **Description:** New `ValidityMask` (bit=1 valid, `mask_==nullptr`=all valid, lazily-allocated shared buffer memset 0xFF, safe + unsafe accessors, bulk `slice/gatherFrom/combine/copy/checkAllValid`).
- **Files:** `src/include/bumblebee/common/types/ValidityMask.hpp:1-140` (new), `src/common/types/ValidityMask.cpp:1-118` (new).
- **Impact:** All-valid path is one pointer null-check — no allocation, no per-row work.


## A2. Vector NULL storage
- **Goal:** Mask flows through flat/constant/dictionary/sequence encodings.
- **Description:** `Vector.validity_`; slice/normalify/orrify propagate into `VectorData`; `setValue` writes a defensive min-value sentinel and clears the bit; `getValue`→`Value::null()`.
- **Files:** `src/common/types/Vector.cpp` (validity threaded throughout; new mask helpers `:538-617`; touch points `:57-67,105-109,267-269,440-443,474-486`), `src/include/bumblebee/common/types/Vector.hpp:128-138,172-175,227-236,281-286`, `src/include/bumblebee/common/types/NullValue.hpp:28-30`.
- **Impact:** NULL travels the whole vectorized pipeline.

## A3. Aggregate NULL semantics
- **Goal:** Skip NULLs; empty/all-null group → NULL (SUM/MIN/MAX/AVG) or 0 (COUNT).
- **Description:** `aggregate_finalize_t` returns `bool` (`false`=emit NULL); update loops take `const ValidityMask*` with an all-valid fast branch; MIN/MAX combine `init = init||other->init` (fixes all-NULL-group garbage leak); `Avg` div-by-zero guard.
- **Files:** `src/function/AggregateFunction.cpp:179-212,306-358`, `src/include/bumblebee/function/AggregateFunction.hpp:36-39,143-144`, `src/include/bumblebee/function/aggregate/{Avg,Count,Min,Max,Sum}.hpp`.
- **Impact:** Correct 3-valued aggregation on all paths.

## A4. Row-layout validity in joins/dedup
- **Goal:** Per-column NULL flags in the HT row layout with correct join-vs-dedup NULL semantics.
- **Description:** Validity-bitmap prefix at row offset 0 (`flagWidth_`); `RowMatch` templated on `NOT_DISTINCT` → compile-time NULL-excludes (joins) vs IS-NOT-DISTINCT-FROM (dedup/recursion).
- **Files:** `src/common/types/RowLayout.cpp:32-35`, `src/include/bumblebee/common/types/RowLayout.hpp:29-36,93-97,116-117`, `src/common/row_operations/RowScatter.cpp:89-110`, `src/common/row_operations/RowGather.cpp:42-58,172-182`, `src/common/row_operations/RowMatch.cpp:26-41,301-321` (+ templated throughout), `src/include/bumblebee/common/row_operations/RowOperations.hpp:20-83`.
- **Impact:** Two semantics, zero runtime branching; recursion no longer re-derives null facts forever.

## A5. Comparison / arithmetic three-valued logic
- **Goal:** NULL propagation preserving OR-eval invariants.
- **Description:** `HAS_NULLS`-templated select loops keep null rows in `falseSel`; arithmetic/unary propagate validity; new `isNull/isNotNull/notDistinctFrom/distinctFrom`; wires `IS_NULL/IS_NOT_NULL`.
- **Files:** `src/include/bumblebee/common/vector_operations/BinaryExecution.hpp:109-139,205-334`, `src/include/bumblebee/common/vector_operations/UnaryExecution.hpp:83-165`, `src/common/vector_operations/VectorComparison.cpp:105-106,323-405`, `src/execution/Expression.cpp:192-196,228-233`.
- **Impact:** Correct SQL 3VL for WHERE/arithmetic/casts/IS NULL; fast non-null paths preserved.

## A6. Sort-key NULL ordering
- **Goal:** NULLs last ASC / first DESC (SQL default).
- **Description:** 0xFF fixed-width sentinel + `0x01`/`0x02` string prefix byte; new `encodeNull`/`getNullEncodeLength`; `HAS_NULL`-templated.
- **Files:** `src/common/vector_operations/CreateSortKey.cpp:59-362` (throughout; new null encoders `:333-362`).
- **Impact:** Deterministic ordering, multi-column tie-break correct.

## A7. SQL / Datalog `IS NULL` parsing
- **Goal:** Parse NULL literal + IS [NOT] NULL in both front-ends.
- **Description:** lexer/grammar additions; `Term::createNull()`, **noexcept move ctor**, `Value::isNull_/null()`; `BEGIN(INITIAL)` reset (SQL-mode-bleed fix).
- **Files:** `src/parser/aspcore2.l:110-116`, `src/parser/aspcore2.y:65-66,405-412,474-477,1094-1101`, `src/include/bumblebee/parser/statement/Term.hpp:59,79,128-133,139-143,174-178`, `src/parser/statement/Term.cpp:30,34,104,255-261`, `src/common/types/Value.cpp:28-34,76-78,178,209-211`, `src/include/bumblebee/common/types/Value.hpp:54-58,147-148`, `src/parser/statement/sql/SqlToDatalog.cpp:582-693,1022-1031,1480-1488`, `src/parser/ParserInputDirector.cpp:89-97`. (Regenerated: `aspcore2_parser.*`, `aspcore2_lexer.hpp`.)
- **Impact:** Full IS [NOT] NULL surface + two independent latent-bug fixes.

## A8. Python pandas NA interop
- **Goal:** Round-trip NULLs with pandas/numpy.
- **Description:** reads masked dtypes/NaN/NaT/categorical `-1`/`None`/cached `pandas.NA` → `setInvalid`; output builds correct nullable dtypes; `valueToPython`→`py::none()`.
- **Files:** `python/src/VectorConversion.cpp:30-113,150-266,371-378` (throughout), `python/src/VectorWrapper.cpp:316-332,407-442`, `python/src/PyPredicateTable.cpp:34-38,115-150,168-175`, `python/src/include/VectorWrapper.hpp`.
- **Impact:** DataFrame NULLs survive round-trip with correct nullable dtypes.

## A9. Serialization
- **Goal:** Persist/restore masks in the block format.
- **Description:** `write/readBitmask` — `[allValid:1B][packed bits]`, all-valid fast byte, read resets first.
- **Files:** `src/include/bumblebee/common/serializer/Serializer.hpp:20-24,61-83,142-161`.

## A10. Test coverage
- **Files (new):** `test/unit/bumblebee/common/types/{validity_mask_test,vector_null_test,value_null_test,data_chunk_test}.cpp`, `.../vector_operations/{comparison,arith,copy,sort_keys}_null_test.cpp`, `.../row_operations/row_op_null_test.cpp`, `.../execution/atom/aggregate/agg_null_test.cpp`, `.../execution/atom/join/ht_null_test.cpp`, `.../function/{read_csv,write_csv,write_parquet}_null_test.cpp`, `.../parser/parser_null_test.cpp`, `.../serializer/serializer_bitmask_test.cpp`, `test/unit/bumblebee/NullTestBase.hpp`; e2e `test/e2e/files/{asp,sql}/.../null/*`; `python/test/test_null.py`.

---

# Part B — Performance: parquet scan & memory management

## B1. Fold COUNT(*) over unfiltered parquet into a metadata read
- **Goal:** Answer `COUNT(*)` from the footer row-count, not a full scan.
- **Files:** `src/planner/rewriter/MetadataAggRewriter.cpp:1-194` (new), `src/include/bumblebee/planner/rewriter/MetadataAggRewriter.hpp:1-50` (new), `src/BumbleBeeDB.cpp:150-153` (invocation).
- **Impact:** q00 0.448→0.106s (~4.2×), matching DuckDB; other queries byte-identical.

## B2. Fold MIN/MAX over unfiltered parquet using column stats
- **Goal:** Fold MIN/MAX from column statistics.
- **Files:** `src/planner/rewriter/MetadataAggRewriter.cpp:73-192`, `.../MetadataAggRewriter.hpp:26-27,50-57`, `src/include/bumblebee/storage/statistics/BaseStatistics.hpp:35,61-64`, `src/include/bumblebee/storage/statistics/NumericStatistics.hpp:47`, `src/common/vector_operations/VectorCast.cpp:173-179`, `src/include/bumblebee/parser/statement/Term.hpp:139-143,174-178`, `src/parser/statement/Term.cpp:34,104`, `src/catalog/PredicateTables.cpp:51-57`, `src/planner/optimizer/PhysicalOptimizer.cpp:223-229`, `src/include/bumblebee/common/parquet/ParquetReader.hpp:101-104`.
- **Impact:** MIN/MAX over a whole column becomes a metadata lookup.

## B3. Scan only the selected columns
- **Goal:** Stop building the scan chunk over all 105 columns.
- **Files:** `src/include/bumblebee/function/predicate/ReadParquet.hpp:62-72`, `src/function/predicate/ReadParquet.cpp:140-235`.
- **Impact:** q19 12→8ms, q25 17→13, q26 18→14; wide projections unchanged; byte-identical.

## B4. Apply pushed-down filters per row
- **Goal:** Use pushed filters at row granularity, not just row-group skipping.
- **Files:** `src/planner/filter/ConstantFilter.cpp:23-24,109-204` (core `filterRowsLoop`), `src/include/bumblebee/planner/filter/TableFilter.hpp:20-66`, `.../ConjunctionFilter.hpp:49-53`, `.../ConstantFilter.hpp:36`, `src/common/parquet/ParquetReader.cpp:471-475` (call site), `test/unit/bumblebee/common/parquet_reader/parquet_test.cpp:256-279` (corrected expectations).
- **Impact:** q37 54→37ms, q36 47→43; selective point filters ~5% on 10M rows; byte-identical.

## B5. Batch fast path for fixed-width decode (no NULLs/filters)
- **Goal:** Remove per-row overhead in `offsets/plain`.
- **Files:** `src/include/bumblebee/common/parquet/ColumnReader.hpp:124-133` (`allDefined`), `.../TemplatedColumnReader.hpp:24-25,68-80,104-116`.
- **Impact:** `offsets<int>` instructions −55%; high-cardinality URL GROUP BY ~11%; byte-identical incl. NULL files.

## B6. Reuse + pool decompressed page buffers
- **Goal:** Stop per-page allocation; minor page-faults dominated scan system time.
- **Files:** `src/common/parquet/ColumnReader.cpp:163-233`, `src/include/bumblebee/common/parquet/ColumnReader.hpp:150-179`, `src/include/bumblebee/common/parquet/ResizeableBuffer.hpp:87-94` (`resize` ptr-reset fix), `src/execution/AggregatePRLHashTable.cpp:25-55,83-118` + `.../AggregatePRLHashTable.hpp:87-92` (`internalizeStrings`).
- **Impact:** URL scan 4.49→3.92s; GROUP BY URL ~10%, filtered scan ~17%; valgrind clean; byte-exact.

## B7. Windowed bit-unpacking for RLE/dictionary decode
- **Files:** `src/include/bumblebee/common/parquet/RleBpDecoder.hpp:141-158`.
- **Impact:** at −t 4, byte-identical: q19 −21.6%, q02 −14.4%, q03/q26 −13.2%, …

## B8. Cache parsed parquet footer across readers
- **Files:** `src/common/parquet/ParquetReader.cpp:29-99` (process-wide `path:size:mtime` cache).
- **Impact:** 40M-row COUNT(*) 0.099→0.057s; q26 0.770→0.632s; byte-exact.

## B9. Release per-morsel readers when drained
- **Files:** `src/function/predicate/ReadParquet.cpp:229-237`.
- **Impact:** peak memory q12 −31%, q21 −24%, q25 −20%, …; byte-exact.

## B10. Free `AllocatedData` on destruction (leak fix)
- **Files:** `src/common/Allocator.cpp:29-33` (destructor now calls `reset()`).
- **Impact:** **Most impactful:** q20 peak RSS 3503→124 MB, q21 3564→183 MB (~28×). Byte-exact.

---

# Part C — Performance: core execution / string / hashing / sort / top-N / hash tables

## C1. Word-at-a-time string hashing
- **Files:** `src/common/Hash.cpp:6,70-101`.
- **Impact:** URL GROUP BY ~16%; no integer-key regression.

## C2. Inline BumbleString hot methods + hash wrapper
- **Files:** `src/include/bumblebee/common/types/BumbleString.hpp:20,49-128`, `src/include/bumblebee/common/Hash.hpp:51-58`, `src/common/Hash.cpp:44`, `src/common/types/BumbleString.cpp:26,34`.
- **Impact:** URL GROUP BY instructions −5.4%.

## C3. Const-ref compare operands; simplify string equality
- **Files:** `src/include/bumblebee/common/operator/ComparisonOperators.hpp:29-128` (throughout).
- **Impact:** q12 −14.1%, q14 −8.8%, q33 −7.7%; numeric neutral.

## C4. Faster CSV parse (inline classifiers, no per-field strlen)
- **Files:** `src/include/bumblebee/common/StringUtils.hpp:42-45`, `src/common/StringUtils.cpp:218` (removed), `src/common/BufferedCSVReader.cpp:614-616`.
- **Impact:** COUNT(*) −14.5%, GROUP BY −13.3% on a 204800-row CSV; byte-identical.

## C5. Reduce CSV sniff sample 75→20 chunks
- **Files:** `src/include/bumblebee/common/BufferedCSVReader.hpp:73-80`.
- **Impact:** COUNT(*) 2523→970ms; string GROUP BY ~2.5×.

## C6. `memmem` for LIKE substring search
- **Files:** `src/function/predicate/StringLike.cpp:22-41`.
- **Impact:** LIKE instructions −14%; byte-identical; ~100 lines removed.

## C7. Word-at-a-time ASCII fast path in UTF8 validation
- **Files:** `third_party/utf8proc/utf8proc_wrapper.cpp:35-88`.
- **Impact:** ~5.7× ASCII validation; q20 −8.4%; identical, fuzzed over 20M inputs.

## C8. HT directory sizing: exact capacity, floored at BLOCK_SIZE
- **Files:** `src/execution/PRLHashTable.cpp:301-306` (`347d23c`, exact) then `:306-314` (`5dc0f47`, floor fix).
- **Impact:** GROUP BY 22–34% faster.

## C9. HT load factor 0.5 → 0.6 → 0.75
- **Files:** `src/include/bumblebee/execution/PRLHashTable.hpp:88` (`cbe4dff` 0.6, `53ea908` 0.75).
- **Impact:** 0.6: q32/q07/q03 −7–9%; 0.75: q32 peak RSS 5543→4515 MB, runtime flat-to-better.

## C10. Pre-size aggregation HT from real cardinality — **added then reverted (net zero)**
- **Files (added `62739c0`, reverted `879b99a`):** `src/execution/PhysicalAtom.cpp:116-117`, `src/include/bumblebee/execution/PhysicalAtom.hpp:107-108`, `src/include/bumblebee/function/PredFunction.hpp:74-75`, `src/include/bumblebee/function/predicate/ReadParquet.hpp:68-72`, `src/function/predicate/ReadParquet.cpp` (`getTotalRows`), `src/planner/optimizer/PhysicalOptimizer.cpp:944`, `src/execution/atom/external/PhysicalPredFunction.cpp:62`.

## C11. Tuple-level merge fast path for fixed-width agg keys
- **Files:** `src/execution/AggregatePRLHashTable.cpp:85-161`, `src/include/bumblebee/execution/AggregatePRLHashTable.hpp:77-80`.
- **Impact:** q30 −10.7%, q32 −10.2%; byte-exact.

## C12. Drop dead duplicate key strings when combining agg HTs
- **Files:** `src/execution/PartitionedAggHT.cpp:86-93,241-252`, `src/include/bumblebee/execution/PartitionedAggHT.hpp:172-174`.
- **Impact:** URL GROUP BY 40M rows: agg heap 4894→2438 MB, peak RSS 12.38→7.25 GB (−41%).

## C13. Hash-directory prefetch (+ deeper distance + source tuple)
- **Files:** `src/execution/RowLayoutJoinHashTable.cpp:140,146-151,268-273` (`71e765c` join build/probe), `src/execution/PRLHashTable.cpp:402-407,414` (`0a3513d` group-probe, `b1d5a8c` dist 32), `src/execution/AggregatePRLHashTable.cpp:128-134,169-176` (`4fb949f` merge, `b1d5a8c` dist 32, `52d8f73` source tuple).
- **Impact:** q02 −14.3% (join), group-probe −3–4%, source-tuple q32 −6%.

## C14. Bulk-allocate fixed-width sort-key buffers
- **Files:** `src/common/vector_operations/CreateSortKey.cpp:333-363`.
- **Impact:** q30 −9.0%, q32 −7.4%, q07 −8.0%; byte-identical.

## C15. Top-N: skip/prune sort-key building for non-candidate rows
- **Files:** `src/execution/TopNHeap.cpp:38-133,194-197` + `src/include/bumblebee/execution/TopNHeap.hpp:34-37,99-149` (`7a9f792` whole-chunk, `1251365` row-level `candSel_`/`sinkChunk`).
- **Impact:** q07 2.0×, q26 1.49× then 0.67→0.53s; byte-identical.

## C16. Wake idle workers on shutdown
- **Files:** `src/parallel/TaskExecutor.cpp:36-38,64-69`.
- **Impact:** q00 0.107→0.006s; e2e suite 223→97s.

---

# Part D — Build/toolchain, benchmarks, profiling, examples

## D1. GCC 13 / libstdc++ portability (library + unit tests)
- **Files (`723c93b`):** `CMakeLists.txt:20-27` (force-include prelude), `src/include/std_prelude.hpp:1-23` (new), `src/common/types/Graph.cpp:22` (drop libc++-internal include), `src/parser/ParserInputBuilder.cpp:207,1242,1261` (init order), `src/planner/rewriter/AggregatesRewriter.cpp:154,160` (explicit `vector<Term>`).
  **(`1702ceb`):** `test/unit/bumblebee/execution/topnheap_test.cpp` (init order, many), `test/unit/bumblebee/function/write_csv_test.cpp:34` (member rename), `test/unit/third_party/hll.cpp:78-79` (named array).
- **Impact:** Builds under a second toolchain; 646/648 unit tests pass (2 env failures).

## D2. Emit `-r` profiling report in Release
- **Files:** `src/BumbleBeeDB.cpp:334-337` (`fprintf(stderr,…)` instead of compiled-out `LOG_INFO`).
- **Impact:** `-r` now works in Release.

## D3. Local ClickBench harness + synthetic generator (`6fe2050`)
- **Files:** `benchmarks/gen_synthetic_hits.py` (new, 127), `benchmarks/bench_local.py` (new, 129), `.gitignore:8`.

## D4. LDBC SNB tri-engine benchmark (BumbleBee vs DuckDB vs Neo4j)
- **Files (new):** `benchmarks/LDBC.md` (183), `benchmarks/configs/{bumblebee,duckdb,neo4j}_ldbc.json`, `benchmarks/{prepare_ldbc,ldbc_normalize}.py`, `benchmarks/{neo4j_load.sh,neo4j_load.cypher,run_ldbc.sh}`, `benchmarks/files/ldbc/params.json`; **modified** `benchmarks/benchmark_runner.py:+20/-3`.

## D5. `test_bench.py` (BumbleBee vs pandas) + committed result CSVs
- **Files:** `test_bench.py` (new, 213, **repo root**); `benchmarks/results/*.csv` (git-tracked timestamped results, incl. a new untracked one in the working tree).

## D6. NULL examples + docs
- **Files (new):** `examples/dl/07_null/*`, `examples/sql/08_null/*`, `examples/python/06_null_handling.py`, `examples/data/survey.csv`, `examples/expected/{dl/07_null,sql/08_null}/*`; **modified** `python/test/test_examples.py:+53`, `README.md`, `ROADMAP.md`, `examples/README.md`.

